### PR TITLE
Add Fabio and Jan from OCP storage team as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 approvers:
-  - rgolangh
   - bennyz
-reviewers:
+  - bertinatto
+  - jsafrane
   - rgolangh
-  - bennyz


### PR DESCRIPTION
And remove `reviewers`, they're included in `approvers`.