### PR TITLE
Bug 1863075: Allow the driver to run on any nodes

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -16,8 +16,7 @@ spec:
       serviceAccount: ovirt-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       initContainers:
         - name: prepare-ovirt-config
           env:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -339,8 +339,7 @@ spec:
       serviceAccount: ovirt-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       initContainers:
         - name: prepare-ovirt-config
           env:


### PR DESCRIPTION
So tainted nodes (such as masters) can use PVCs too.