### PR TITLE
Bug 1871050: missing cluster RBAC role for volumeattachments

### DIFF
--- a/manifests/05_clusterrole.yaml
+++ b/manifests/05_clusterrole.yaml
@@ -139,6 +139,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshotcontents/status


### PR DESCRIPTION
this is missing permissions to complete https://github.com/openshift/ovirt-csi-driver-operator/pull/21

Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>