### PR TITLE
Bug 1876791: Update provisioner container to v2.0.0

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -106,9 +106,8 @@ spec:
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           args:
-            - --provisioner=csi.ovirt.org
             - --csi-address=$(ADDRESS)
-            - --feature-gates=Topology=true
+            - --default-fstype=ext4
             - --v=${LOG_LEVEL}
           env:
             - name: ADDRESS

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -178,9 +178,8 @@ spec:
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           args:
-            - --provisioner=csi.ovirt.org
             - --csi-address=$(ADDRESS)
-            - --feature-gates=Topology=true
+            - --default-fstype=ext4
             - --v=${LOG_LEVEL}
           env:
             - name: ADDRESS


### PR DESCRIPTION
- `--provisioner` has been deprecated and removed upstream.
- add `--default-fstype=ext4` to explicitly default to ext4 (newly introduced in v2.0.0)
- remove useless topology feature

@openshift/storage 