### PR TITLE
Bug 1879406: Use port 10300-10301 for liveness probes

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -131,6 +131,19 @@ spec:
             requests:
               memory: 50Mi
               cpu: 10m
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=10301
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -92,7 +92,8 @@ spec:
               value: /tmp/config/ovirt-config.yaml
           ports:
             - name: healthz
-              containerPort: 19808
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10301
               protocol: TCP
           volumeMounts:
             - name: socket-dir

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -103,7 +103,8 @@ spec:
 
           ports:
             - name: healthz
-              containerPort: 9808
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10300
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -148,6 +149,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
+            - --health-port=10300
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -203,6 +203,19 @@ spec:
             requests:
               memory: 50Mi
               cpu: 10m
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=10301
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -425,6 +438,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
+            - --health-port=10300
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -164,7 +164,8 @@ spec:
               value: /tmp/config/ovirt-config.yaml
           ports:
             - name: healthz
-              containerPort: 19808
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10301
               protocol: TCP
           volumeMounts:
             - name: socket-dir
@@ -378,7 +379,8 @@ spec:
 
           ports:
             - name: healthz
-              containerPort: 9808
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10300
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
[9xxx range is allowed to be accessible from outside of nodes](https://github.com/openshift/openshift-docs/blob/master/modules/installation-network-user-infra.adoc) and we don't need that for CSI driver liveness probes.

Using 10300 does not make it blocked by firewall, but at least it's not in the list of open ports and it's blocked in IPI.

@openshift/storage, @bennyz @rgolangh 