### PR TITLE
Bug 1896320: Bail immediately if we failed to create an OvirtClient

### DIFF
--- a/cmd/ovirt-csi-driver-operator/main.go
+++ b/cmd/ovirt-csi-driver-operator/main.go
@@ -38,7 +38,11 @@ func main() {
 }
 
 func NewOperatorCommand() *cobra.Command {
-	op, _ := operator.NewCSIOperator(&nodeName)
+	op, err := operator.NewCSIOperator(&nodeName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 
 	cmd := &cobra.Command{
 		Use:   "ovirt-csi-driver-operator",


### PR DESCRIPTION
If we failed to construct NewCSIOperator (likely because of connection issues), we should bail immediately to make the logs much more easier to read when troubleshooting