### PR TITLE
bump go-ovirt to 2020-10-23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/openshift/api v0.0.0-20200827090112-c05698d102cf
 	github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7
 	github.com/openshift/library-go v0.0.0-20200909173121-1d055d971916
-	github.com/ovirt/go-ovirt v0.0.0-20200709024803-dab75bb9273d
+	github.com/ovirt/go-ovirt v0.0.0-20201023070830-77e357c438d5
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mo
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/library-go v0.0.0-20200909173121-1d055d971916 h1:H9XwZlu78Pn87KNBGGjZY0L2fLOoPnzEajigVur5ZOY=
 github.com/openshift/library-go v0.0.0-20200909173121-1d055d971916/go.mod h1:6vwp+YhYOIlj8MpkQKkebTTSn2TuYyvgiAFQ206jIEQ=
-github.com/ovirt/go-ovirt v0.0.0-20200709024803-dab75bb9273d h1:eOX+uElq0EVlQh3THnLs7wkxBz4yZdyjMCRIBCIxKao=
-github.com/ovirt/go-ovirt v0.0.0-20200709024803-dab75bb9273d/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
+github.com/ovirt/go-ovirt v0.0.0-20201023070830-77e357c438d5 h1:xU3p8lGWaKEsqdRNw3wkmfDypCKezVSYC2Yx0rvgViw=
+github.com/ovirt/go-ovirt v0.0.0-20201023070830-77e357c438d5/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/ovirt/go-ovirt/CHANGES.adoc
+++ b/vendor/github.com/ovirt/go-ovirt/CHANGES.adoc
@@ -2,6 +2,40 @@
 
 This document describes the relevant changes between releases of the SDK.
 
+== 4.4.2 / Oct 13 2020
+
+Update to model 4.4.19 and metamodel 1.3.3
+
+New features:
+
+* Add add_cluster.go and add new examples
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/196[GitHub-196]
+
+* Tries the connection token aquired in `Test()` method
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/197[GitHub-197]
+
+* Add CACert attribute to connection
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/203[GitHub-203]
+
+* Add new example set_vm_comment.go for sdk
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/212[Github-212]
+
+
+Bug fixes:
+
+* Fix error handling in case token request errors
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/204[GitHub-204]
+
+* Networks parsing problem
+  https://bugzilla.redhat.com/1841556[1841556].
+
+* Fix show_summary and add check_OCP_support
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/211[Github-211]
+
+* Check if follow link response is not nil
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/215[Github-215]
+
+
 == 4.4.1 / Jan 31 2020
 
 Bug fixes:

--- a/vendor/github.com/ovirt/go-ovirt/readers.go
+++ b/vendor/github.com/ovirt/go-ovirt/readers.go
@@ -4943,6 +4943,12 @@ func XMLMacPoolReadOne(reader *XMLReader, start *xml.StartElement, expectedTag s
 					return nil, err
 				}
 				builder.Name(v)
+			case "permissions":
+				v, err := XMLPermissionReadMany(reader, &t)
+				if err != nil {
+					return nil, err
+				}
+				builder.Permissions(v)
 			case "ranges":
 				v, err := XMLRangeReadMany(reader, &t)
 				if err != nil {
@@ -4979,6 +4985,11 @@ func XMLMacPoolReadOne(reader *XMLReader, start *xml.StartElement, expectedTag s
 	}
 	for _, link := range links {
 		switch *link.rel {
+		case "permissions":
+			if one.permissions == nil {
+				one.permissions = new(PermissionSlice)
+			}
+			one.permissions.href = link.href
 		} // end of switch
 	} // end of for-links
 	return one, nil
@@ -5172,6 +5183,17 @@ func XMLProductInfoReadOne(reader *XMLReader, start *xml.StartElement, expectedT
 	}
 	if start.Name.Local != expectedTag {
 		return nil, XMLTagNotMatchError{start.Name.Local, expectedTag}
+	}
+	// Process the attributes
+	for _, attr := range start.Attr {
+		name := attr.Name.Local
+		value := attr.Value
+		switch name {
+		case "id":
+			builder.Id(value)
+		case "href":
+			builder.Href(value)
+		}
 	}
 	var links []Link
 	depth := 1
@@ -7452,12 +7474,12 @@ func XMLImageTransferReadOne(reader *XMLReader, start *xml.StartElement, expecte
 					return nil, err
 				}
 				builder.ProxyUrl(v)
-			case "signed_ticket":
-				v, err := reader.ReadString(&t)
+			case "shallow":
+				v, err := reader.ReadBool(&t)
 				if err != nil {
 					return nil, err
 				}
-				builder.SignedTicket(v)
+				builder.Shallow(v)
 			case "snapshot":
 				v, err := XMLDiskSnapshotReadOne(reader, &t, "snapshot")
 				if err != nil {
@@ -22045,6 +22067,12 @@ func XMLNetworkReadOne(reader *XMLReader, start *xml.StartElement, expectedTag s
 					return nil, err
 				}
 				builder.Permissions(v)
+			case "port_isolation":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.PortIsolation(v)
 			case "profile_required":
 				v, err := reader.ReadBool(&t)
 				if err != nil {
@@ -22887,6 +22915,174 @@ func XMLHardwareInformationReadMany(reader *XMLReader, start *xml.StartElement) 
 			switch t.Name.Local {
 			case "hardware_information":
 				one, err := XMLHardwareInformationReadOne(reader, &t, "hardware_information")
+				if err != nil {
+					return nil, err
+				}
+				if one != nil {
+					result.slice = append(result.slice, one)
+				}
+			default:
+				reader.Skip()
+			}
+		case xml.EndElement:
+			depth--
+		}
+	}
+	return &result, nil
+}
+
+func XMLCheckpointReadOne(reader *XMLReader, start *xml.StartElement, expectedTag string) (*Checkpoint, error) {
+	builder := NewCheckpointBuilder()
+	if start == nil {
+		st, err := reader.FindStartElement()
+		if err != nil {
+			if err == io.EOF {
+				return nil, nil
+			}
+			return nil, err
+		}
+		start = st
+	}
+	if expectedTag == "" {
+		expectedTag = "checkpoint"
+	}
+	if start.Name.Local != expectedTag {
+		return nil, XMLTagNotMatchError{start.Name.Local, expectedTag}
+	}
+	// Process the attributes
+	for _, attr := range start.Attr {
+		name := attr.Name.Local
+		value := attr.Value
+		switch name {
+		case "id":
+			builder.Id(value)
+		case "href":
+			builder.Href(value)
+		}
+	}
+	var links []Link
+	depth := 1
+	for depth > 0 {
+		t, err := reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		t = xml.CopyToken(t)
+		switch t := t.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "comment":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.Comment(v)
+			case "creation_date":
+				v, err := reader.ReadTime(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.CreationDate(v)
+			case "description":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.Description(v)
+			case "disks":
+				v, err := XMLDiskReadMany(reader, &t)
+				if err != nil {
+					return nil, err
+				}
+				builder.Disks(v)
+			case "name":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.Name(v)
+			case "parent_id":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.ParentId(v)
+			case "vm":
+				v, err := XMLVmReadOne(reader, &t, "vm")
+				if err != nil {
+					return nil, err
+				}
+				builder.Vm(v)
+			case "link":
+				var rel, href string
+				for _, attr := range t.Attr {
+					name := attr.Name.Local
+					value := attr.Value
+					switch name {
+					case "href":
+						href = value
+					case "rel":
+						rel = value
+					}
+				}
+				if rel != "" && href != "" {
+					links = append(links, Link{&href, &rel})
+				}
+				// <link> just has attributes, so must skip manually
+				reader.Skip()
+			default:
+				reader.Skip()
+			}
+		case xml.EndElement:
+			depth--
+		}
+	}
+	one, err := builder.Build()
+	if err != nil {
+		return nil, err
+	}
+	for _, link := range links {
+		switch *link.rel {
+		case "disks":
+			if one.disks == nil {
+				one.disks = new(DiskSlice)
+			}
+			one.disks.href = link.href
+		} // end of switch
+	} // end of for-links
+	return one, nil
+}
+
+func XMLCheckpointReadMany(reader *XMLReader, start *xml.StartElement) (*CheckpointSlice, error) {
+	if start == nil {
+		st, err := reader.FindStartElement()
+		if err != nil {
+			if err == io.EOF {
+				return nil, nil
+			}
+			return nil, err
+		}
+		start = st
+	}
+	var result CheckpointSlice
+	depth := 1
+	for depth > 0 {
+		t, err := reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		t = xml.CopyToken(t)
+		switch t := t.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "checkpoint":
+				one, err := XMLCheckpointReadOne(reader, &t, "checkpoint")
 				if err != nil {
 					return nil, err
 				}
@@ -26961,6 +27157,18 @@ func XMLDiskSnapshotReadOne(reader *XMLReader, start *xml.StartElement, expected
 					return nil, err
 				}
 				builder.DiskProfile(v)
+			case "disk_snapshots":
+				v, err := XMLDiskSnapshotReadMany(reader, &t)
+				if err != nil {
+					return nil, err
+				}
+				builder.DiskSnapshots(v)
+			case "external_disk":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.ExternalDisk(v)
 			case "format":
 				vp, err := XMLDiskFormatReadOne(reader, &t)
 				v := *vp
@@ -27017,6 +27225,12 @@ func XMLDiskSnapshotReadOne(reader *XMLReader, start *xml.StartElement, expected
 					return nil, err
 				}
 				builder.OpenstackVolumeType(v)
+			case "parent":
+				v, err := XMLDiskSnapshotReadOne(reader, &t, "parent")
+				if err != nil {
+					return nil, err
+				}
+				builder.Parent(v)
 			case "permissions":
 				v, err := XMLPermissionReadMany(reader, &t)
 				if err != nil {
@@ -27177,6 +27391,11 @@ func XMLDiskSnapshotReadOne(reader *XMLReader, start *xml.StartElement, expected
 	}
 	for _, link := range links {
 		switch *link.rel {
+		case "disksnapshots":
+			if one.diskSnapshots == nil {
+				one.diskSnapshots = new(DiskSnapshotSlice)
+			}
+			one.diskSnapshots.href = link.href
 		case "permissions":
 			if one.permissions == nil {
 				one.permissions = new(PermissionSlice)
@@ -28292,6 +28511,18 @@ func XMLDiskReadOne(reader *XMLReader, start *xml.StartElement, expectedTag stri
 					return nil, err
 				}
 				builder.DiskProfile(v)
+			case "disk_snapshots":
+				v, err := XMLDiskSnapshotReadMany(reader, &t)
+				if err != nil {
+					return nil, err
+				}
+				builder.DiskSnapshots(v)
+			case "external_disk":
+				v, err := reader.ReadString(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.ExternalDisk(v)
 			case "format":
 				vp, err := XMLDiskFormatReadOne(reader, &t)
 				v := *vp
@@ -28508,6 +28739,11 @@ func XMLDiskReadOne(reader *XMLReader, start *xml.StartElement, expectedTag stri
 	}
 	for _, link := range links {
 		switch *link.rel {
+		case "disksnapshots":
+			if one.diskSnapshots == nil {
+				one.diskSnapshots = new(DiskSnapshotSlice)
+			}
+			one.diskSnapshots.href = link.href
 		case "permissions":
 			if one.permissions == nil {
 				one.permissions = new(PermissionSlice)
@@ -30037,6 +30273,12 @@ func XMLClusterReadOne(reader *XMLReader, start *xml.StartElement, expectedTag s
 					return nil, err
 				}
 				builder.VirtService(v)
+			case "vnc_encryption":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.VncEncryption(v)
 			case "link":
 				var rel, href string
 				for _, attr := range t.Attr {
@@ -35061,6 +35303,12 @@ func XMLHostReadOne(reader *XMLReader, start *xml.StartElement, expectedTag stri
 					return nil, err
 				}
 				builder.Protocol(v)
+			case "reinstallation_required":
+				v, err := reader.ReadBool(&t)
+				if err != nil {
+					return nil, err
+				}
+				builder.ReinstallationRequired(v)
 			case "root_password":
 				v, err := reader.ReadString(&t)
 				if err != nil {
@@ -36438,6 +36686,13 @@ func XMLActionReadOne(reader *XMLReader, start *xml.StartElement, expectedTag st
 					return nil, err
 				}
 				builder.AuthorizedKey(v)
+			case "auto_pinning_policy":
+				vp, err := XMLAutoPinningPolicyReadOne(reader, &t)
+				v := *vp
+				if err != nil {
+					return nil, err
+				}
+				builder.AutoPinningPolicy(v)
 			case "bricks":
 				v, err := XMLGlusterBrickReadMany(reader, &t)
 				if err != nil {
@@ -38986,6 +39241,62 @@ func XMLQosTypeReadMany(reader *XMLReader, start *xml.StartElement) ([]QosType, 
 				return nil, err
 			}
 			results = append(results, QosType(one))
+		case xml.EndElement:
+			depth--
+		}
+	}
+	return results, nil
+}
+
+func XMLAutoPinningPolicyReadOne(reader *XMLReader, start *xml.StartElement) (*AutoPinningPolicy, error) {
+	if start == nil {
+		st, err := reader.FindStartElement()
+		if err != nil {
+			if err == io.EOF {
+				return nil, nil
+			}
+			return nil, err
+		}
+		start = st
+	}
+	s, err := reader.ReadString(start)
+	if err != nil {
+		return nil, err
+	}
+	result := new(AutoPinningPolicy)
+	*result = AutoPinningPolicy(s)
+	return result, nil
+}
+
+func XMLAutoPinningPolicyReadMany(reader *XMLReader, start *xml.StartElement) ([]AutoPinningPolicy, error) {
+	if start == nil {
+		st, err := reader.FindStartElement()
+		if err != nil {
+			if err == io.EOF {
+				return nil, nil
+			}
+			return nil, err
+		}
+		start = st
+	}
+	var results []AutoPinningPolicy
+	depth := 1
+	for depth > 0 {
+		t, err := reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		t = xml.CopyToken(t)
+		switch t := t.(type) {
+		case xml.StartElement:
+			one, err := reader.ReadString(&t)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, AutoPinningPolicy(one))
 		case xml.EndElement:
 			depth--
 		}

--- a/vendor/github.com/ovirt/go-ovirt/services.go
+++ b/vendor/github.com/ovirt/go-ovirt/services.go
@@ -8807,6 +8807,172 @@ func (op *VmHostDeviceService) String() string {
 
 //
 //
+type VmCheckpointDiskService struct {
+	BaseService
+}
+
+func NewVmCheckpointDiskService(connection *Connection, path string) *VmCheckpointDiskService {
+	var result VmCheckpointDiskService
+	result.connection = connection
+	result.path = path
+	return &result
+}
+
+//
+// Retrieves the description of the disk.
+//
+type VmCheckpointDiskServiceGetRequest struct {
+	VmCheckpointDiskService *VmCheckpointDiskService
+	header                  map[string]string
+	query                   map[string]string
+	follow                  *string
+}
+
+func (p *VmCheckpointDiskServiceGetRequest) Header(key, value string) *VmCheckpointDiskServiceGetRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *VmCheckpointDiskServiceGetRequest) Query(key, value string) *VmCheckpointDiskServiceGetRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *VmCheckpointDiskServiceGetRequest) Follow(follow string) *VmCheckpointDiskServiceGetRequest {
+	p.follow = &follow
+	return p
+}
+
+func (p *VmCheckpointDiskServiceGetRequest) Send() (*VmCheckpointDiskServiceGetResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.VmCheckpointDiskService.connection.URL(), p.VmCheckpointDiskService.path)
+	values := make(url.Values)
+	if p.follow != nil {
+		values["follow"] = []string{fmt.Sprintf("%v", *p.follow)}
+	}
+
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.VmCheckpointDiskService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.VmCheckpointDiskService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.VmCheckpointDiskService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.VmCheckpointDiskService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.VmCheckpointDiskService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLDiskReadOne(reader, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return &VmCheckpointDiskServiceGetResponse{disk: result}, nil
+}
+
+func (p *VmCheckpointDiskServiceGetRequest) MustSend() *VmCheckpointDiskServiceGetResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Retrieves the description of the disk.
+//
+type VmCheckpointDiskServiceGetResponse struct {
+	disk *Disk
+}
+
+func (p *VmCheckpointDiskServiceGetResponse) Disk() (*Disk, bool) {
+	if p.disk != nil {
+		return p.disk, true
+	}
+	return nil, false
+}
+
+func (p *VmCheckpointDiskServiceGetResponse) MustDisk() *Disk {
+	if p.disk == nil {
+		panic("disk in response does not exist")
+	}
+	return p.disk
+}
+
+//
+// Retrieves the description of the disk.
+//
+func (p *VmCheckpointDiskService) Get() *VmCheckpointDiskServiceGetRequest {
+	return &VmCheckpointDiskServiceGetRequest{VmCheckpointDiskService: p}
+}
+
+//
+// Service locator method, returns individual service on which the URI is dispatched.
+//
+func (op *VmCheckpointDiskService) Service(path string) (Service, error) {
+	if path == "" {
+		return op, nil
+	}
+	return nil, fmt.Errorf("The path <%s> doesn't correspond to any service", path)
+}
+
+func (op *VmCheckpointDiskService) String() string {
+	return fmt.Sprintf("VmCheckpointDiskService:%s", op.path)
+}
+
+//
+//
 type HostNumaNodesService struct {
 	BaseService
 }
@@ -47268,6 +47434,8 @@ func (p *HostService) CommitNetConfig() *HostServiceCommitNetConfigRequest {
 
 //
 // Copy the network configuration of the specified host to current host.
+// IMPORTANT: Any network attachments that are not present on the source host will be erased from the target host
+// by the copy operation.
 // To copy networks from another host, send a request like this:
 // [source]
 // ----
@@ -47277,7 +47445,7 @@ func (p *HostService) CommitNetConfig() *HostServiceCommitNetConfigRequest {
 // [source,xml]
 // ----
 // <action>
-//    <sourceHost id="456" />
+//    <source_host id="456"/>
 // </action>
 // ----
 //
@@ -47398,6 +47566,8 @@ func (p *HostServiceCopyHostNetworksRequest) MustSend() *HostServiceCopyHostNetw
 
 //
 // Copy the network configuration of the specified host to current host.
+// IMPORTANT: Any network attachments that are not present on the source host will be erased from the target host
+// by the copy operation.
 // To copy networks from another host, send a request like this:
 // [source]
 // ----
@@ -47407,7 +47577,7 @@ func (p *HostServiceCopyHostNetworksRequest) MustSend() *HostServiceCopyHostNetw
 // [source,xml]
 // ----
 // <action>
-//    <sourceHost id="456" />
+//    <source_host id="456"/>
 // </action>
 // ----
 //
@@ -47416,6 +47586,8 @@ type HostServiceCopyHostNetworksResponse struct {
 
 //
 // Copy the network configuration of the specified host to current host.
+// IMPORTANT: Any network attachments that are not present on the source host will be erased from the target host
+// by the copy operation.
 // To copy networks from another host, send a request like this:
 // [source]
 // ----
@@ -47425,7 +47597,7 @@ type HostServiceCopyHostNetworksResponse struct {
 // [source,xml]
 // ----
 // <action>
-//    <sourceHost id="456" />
+//    <source_host id="456"/>
 // </action>
 // ----
 //
@@ -48286,9 +48458,10 @@ func (p *HostService) Get() *HostServiceGetRequest {
 // --data '
 // {
 //   "root_password": "myrootpassword"
+// "deploy_hosted_engine" : "true"
 // }
 // ' \
-// "https://engine.example.com/ovirt-engine/api/hosts/123?deploy_hosted_engine=true"
+// "https://engine.example.com/ovirt-engine/api/hosts/123"
 // ----
 // IMPORTANT: Since version 4.1.2 of the engine, when a host is reinstalled we override the host firewall
 // definitions by default.
@@ -48498,9 +48671,10 @@ func (p *HostServiceInstallRequest) MustSend() *HostServiceInstallResponse {
 // --data '
 // {
 //   "root_password": "myrootpassword"
+// "deploy_hosted_engine" : "true"
 // }
 // ' \
-// "https://engine.example.com/ovirt-engine/api/hosts/123?deploy_hosted_engine=true"
+// "https://engine.example.com/ovirt-engine/api/hosts/123"
 // ----
 // IMPORTANT: Since version 4.1.2 of the engine, when a host is reinstalled we override the host firewall
 // definitions by default.
@@ -48546,9 +48720,10 @@ type HostServiceInstallResponse struct {
 // --data '
 // {
 //   "root_password": "myrootpassword"
+// "deploy_hosted_engine" : "true"
 // }
 // ' \
-// "https://engine.example.com/ovirt-engine/api/hosts/123?deploy_hosted_engine=true"
+// "https://engine.example.com/ovirt-engine/api/hosts/123"
 // ----
 // IMPORTANT: Since version 4.1.2 of the engine, when a host is reinstalled we override the host firewall
 // definitions by default.
@@ -58283,13 +58458,14 @@ func NewVmsService(connection *Connection, path string) *VmsService {
 // In all cases the name or identifier of the cluster where the virtual machine will be created is mandatory.
 //
 type VmsServiceAddRequest struct {
-	VmsService       *VmsService
-	header           map[string]string
-	query            map[string]string
-	clone            *bool
-	clonePermissions *bool
-	filter           *bool
-	vm               *Vm
+	VmsService        *VmsService
+	header            map[string]string
+	query             map[string]string
+	autoPinningPolicy *AutoPinningPolicy
+	clone             *bool
+	clonePermissions  *bool
+	filter            *bool
+	vm                *Vm
 }
 
 func (p *VmsServiceAddRequest) Header(key, value string) *VmsServiceAddRequest {
@@ -58305,6 +58481,11 @@ func (p *VmsServiceAddRequest) Query(key, value string) *VmsServiceAddRequest {
 		p.query = make(map[string]string)
 	}
 	p.query[key] = value
+	return p
+}
+
+func (p *VmsServiceAddRequest) AutoPinningPolicy(autoPinningPolicy AutoPinningPolicy) *VmsServiceAddRequest {
+	p.autoPinningPolicy = &autoPinningPolicy
 	return p
 }
 
@@ -58331,6 +58512,10 @@ func (p *VmsServiceAddRequest) Vm(vm *Vm) *VmsServiceAddRequest {
 func (p *VmsServiceAddRequest) Send() (*VmsServiceAddResponse, error) {
 	rawURL := fmt.Sprintf("%s%s", p.VmsService.connection.URL(), p.VmsService.path)
 	values := make(url.Values)
+	if p.autoPinningPolicy != nil {
+		values["auto_pinning_policy"] = []string{fmt.Sprintf("%v", *p.autoPinningPolicy)}
+	}
+
 	if p.clone != nil {
 		values["clone"] = []string{fmt.Sprintf("%v", *p.clone)}
 	}
@@ -58723,13 +58908,14 @@ func (p *VmsService) Add() *VmsServiceAddRequest {
 // add a virtual machine to the system from a configuration - requires the configuration type and the configuration data
 //
 type VmsServiceAddFromConfigurationRequest struct {
-	VmsService       *VmsService
-	header           map[string]string
-	query            map[string]string
-	clone            *bool
-	clonePermissions *bool
-	filter           *bool
-	vm               *Vm
+	VmsService        *VmsService
+	header            map[string]string
+	query             map[string]string
+	autoPinningPolicy *AutoPinningPolicy
+	clone             *bool
+	clonePermissions  *bool
+	filter            *bool
+	vm                *Vm
 }
 
 func (p *VmsServiceAddFromConfigurationRequest) Header(key, value string) *VmsServiceAddFromConfigurationRequest {
@@ -58745,6 +58931,11 @@ func (p *VmsServiceAddFromConfigurationRequest) Query(key, value string) *VmsSer
 		p.query = make(map[string]string)
 	}
 	p.query[key] = value
+	return p
+}
+
+func (p *VmsServiceAddFromConfigurationRequest) AutoPinningPolicy(autoPinningPolicy AutoPinningPolicy) *VmsServiceAddFromConfigurationRequest {
+	p.autoPinningPolicy = &autoPinningPolicy
 	return p
 }
 
@@ -58771,6 +58962,9 @@ func (p *VmsServiceAddFromConfigurationRequest) Vm(vm *Vm) *VmsServiceAddFromCon
 func (p *VmsServiceAddFromConfigurationRequest) Send() (*VmsServiceAddFromConfigurationResponse, error) {
 	rawURL := fmt.Sprintf("%s%s/fromconfiguration", p.VmsService.connection.URL(), p.VmsService.path)
 	actionBuilder := NewActionBuilder()
+	if p.autoPinningPolicy != nil {
+		actionBuilder.AutoPinningPolicy(*p.autoPinningPolicy)
+	}
 	if p.clone != nil {
 		actionBuilder.Clone(*p.clone)
 	}
@@ -58888,13 +59082,14 @@ func (p *VmsService) AddFromConfiguration() *VmsServiceAddFromConfigurationReque
 // add a virtual machine to the system from scratch
 //
 type VmsServiceAddFromScratchRequest struct {
-	VmsService       *VmsService
-	header           map[string]string
-	query            map[string]string
-	clone            *bool
-	clonePermissions *bool
-	filter           *bool
-	vm               *Vm
+	VmsService        *VmsService
+	header            map[string]string
+	query             map[string]string
+	autoPinningPolicy *AutoPinningPolicy
+	clone             *bool
+	clonePermissions  *bool
+	filter            *bool
+	vm                *Vm
 }
 
 func (p *VmsServiceAddFromScratchRequest) Header(key, value string) *VmsServiceAddFromScratchRequest {
@@ -58910,6 +59105,11 @@ func (p *VmsServiceAddFromScratchRequest) Query(key, value string) *VmsServiceAd
 		p.query = make(map[string]string)
 	}
 	p.query[key] = value
+	return p
+}
+
+func (p *VmsServiceAddFromScratchRequest) AutoPinningPolicy(autoPinningPolicy AutoPinningPolicy) *VmsServiceAddFromScratchRequest {
+	p.autoPinningPolicy = &autoPinningPolicy
 	return p
 }
 
@@ -58936,6 +59136,9 @@ func (p *VmsServiceAddFromScratchRequest) Vm(vm *Vm) *VmsServiceAddFromScratchRe
 func (p *VmsServiceAddFromScratchRequest) Send() (*VmsServiceAddFromScratchResponse, error) {
 	rawURL := fmt.Sprintf("%s%s/fromscratch", p.VmsService.connection.URL(), p.VmsService.path)
 	actionBuilder := NewActionBuilder()
+	if p.autoPinningPolicy != nil {
+		actionBuilder.AutoPinningPolicy(*p.autoPinningPolicy)
+	}
 	if p.clone != nil {
 		actionBuilder.Clone(*p.clone)
 	}
@@ -59053,13 +59256,14 @@ func (p *VmsService) AddFromScratch() *VmsServiceAddFromScratchRequest {
 // add a virtual machine to the system by cloning from a snapshot
 //
 type VmsServiceAddFromSnapshotRequest struct {
-	VmsService       *VmsService
-	header           map[string]string
-	query            map[string]string
-	clone            *bool
-	clonePermissions *bool
-	filter           *bool
-	vm               *Vm
+	VmsService        *VmsService
+	header            map[string]string
+	query             map[string]string
+	autoPinningPolicy *AutoPinningPolicy
+	clone             *bool
+	clonePermissions  *bool
+	filter            *bool
+	vm                *Vm
 }
 
 func (p *VmsServiceAddFromSnapshotRequest) Header(key, value string) *VmsServiceAddFromSnapshotRequest {
@@ -59075,6 +59279,11 @@ func (p *VmsServiceAddFromSnapshotRequest) Query(key, value string) *VmsServiceA
 		p.query = make(map[string]string)
 	}
 	p.query[key] = value
+	return p
+}
+
+func (p *VmsServiceAddFromSnapshotRequest) AutoPinningPolicy(autoPinningPolicy AutoPinningPolicy) *VmsServiceAddFromSnapshotRequest {
+	p.autoPinningPolicy = &autoPinningPolicy
 	return p
 }
 
@@ -59101,6 +59310,9 @@ func (p *VmsServiceAddFromSnapshotRequest) Vm(vm *Vm) *VmsServiceAddFromSnapshot
 func (p *VmsServiceAddFromSnapshotRequest) Send() (*VmsServiceAddFromSnapshotResponse, error) {
 	rawURL := fmt.Sprintf("%s%s/fromsnapshot", p.VmsService.connection.URL(), p.VmsService.path)
 	actionBuilder := NewActionBuilder()
+	if p.autoPinningPolicy != nil {
+		actionBuilder.AutoPinningPolicy(*p.autoPinningPolicy)
+	}
 	if p.clone != nil {
 		actionBuilder.Clone(*p.clone)
 	}
@@ -59228,6 +59440,7 @@ type VmsServiceListRequest struct {
 	filter        *bool
 	follow        *string
 	max           *int64
+	ovfAsOva      *bool
 	search        *string
 }
 
@@ -59272,6 +59485,11 @@ func (p *VmsServiceListRequest) Max(max int64) *VmsServiceListRequest {
 	return p
 }
 
+func (p *VmsServiceListRequest) OvfAsOva(ovfAsOva bool) *VmsServiceListRequest {
+	p.ovfAsOva = &ovfAsOva
+	return p
+}
+
 func (p *VmsServiceListRequest) Search(search string) *VmsServiceListRequest {
 	p.search = &search
 	return p
@@ -59298,6 +59516,10 @@ func (p *VmsServiceListRequest) Send() (*VmsServiceListResponse, error) {
 
 	if p.max != nil {
 		values["max"] = []string{fmt.Sprintf("%v", *p.max)}
+	}
+
+	if p.ovfAsOva != nil {
+		values["ovf_as_ova"] = []string{fmt.Sprintf("%v", *p.ovfAsOva)}
 	}
 
 	if p.search != nil {
@@ -62150,6 +62372,7 @@ type DiskSnapshotsServiceListRequest struct {
 	header               map[string]string
 	query                map[string]string
 	follow               *string
+	includeActive        *bool
 	max                  *int64
 }
 
@@ -62174,6 +62397,11 @@ func (p *DiskSnapshotsServiceListRequest) Follow(follow string) *DiskSnapshotsSe
 	return p
 }
 
+func (p *DiskSnapshotsServiceListRequest) IncludeActive(includeActive bool) *DiskSnapshotsServiceListRequest {
+	p.includeActive = &includeActive
+	return p
+}
+
 func (p *DiskSnapshotsServiceListRequest) Max(max int64) *DiskSnapshotsServiceListRequest {
 	p.max = &max
 	return p
@@ -62184,6 +62412,10 @@ func (p *DiskSnapshotsServiceListRequest) Send() (*DiskSnapshotsServiceListRespo
 	values := make(url.Values)
 	if p.follow != nil {
 		values["follow"] = []string{fmt.Sprintf("%v", *p.follow)}
+	}
+
+	if p.includeActive != nil {
+		values["include_active"] = []string{fmt.Sprintf("%v", *p.includeActive)}
 	}
 
 	if p.max != nil {
@@ -63422,6 +63654,194 @@ func (op *DataCenterService) Service(path string) (Service, error) {
 
 func (op *DataCenterService) String() string {
 	return fmt.Sprintf("DataCenterService:%s", op.path)
+}
+
+//
+// Lists the checkpoints of a virtual machine.
+//
+type VmCheckpointsService struct {
+	BaseService
+}
+
+func NewVmCheckpointsService(connection *Connection, path string) *VmCheckpointsService {
+	var result VmCheckpointsService
+	result.connection = connection
+	result.path = path
+	return &result
+}
+
+//
+// The list of virtual machine checkpoints.
+//
+type VmCheckpointsServiceListRequest struct {
+	VmCheckpointsService *VmCheckpointsService
+	header               map[string]string
+	query                map[string]string
+	follow               *string
+	max                  *int64
+}
+
+func (p *VmCheckpointsServiceListRequest) Header(key, value string) *VmCheckpointsServiceListRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *VmCheckpointsServiceListRequest) Query(key, value string) *VmCheckpointsServiceListRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *VmCheckpointsServiceListRequest) Follow(follow string) *VmCheckpointsServiceListRequest {
+	p.follow = &follow
+	return p
+}
+
+func (p *VmCheckpointsServiceListRequest) Max(max int64) *VmCheckpointsServiceListRequest {
+	p.max = &max
+	return p
+}
+
+func (p *VmCheckpointsServiceListRequest) Send() (*VmCheckpointsServiceListResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.VmCheckpointsService.connection.URL(), p.VmCheckpointsService.path)
+	values := make(url.Values)
+	if p.follow != nil {
+		values["follow"] = []string{fmt.Sprintf("%v", *p.follow)}
+	}
+
+	if p.max != nil {
+		values["max"] = []string{fmt.Sprintf("%v", *p.max)}
+	}
+
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.VmCheckpointsService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.VmCheckpointsService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.VmCheckpointsService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.VmCheckpointsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.VmCheckpointsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLCheckpointReadMany(reader, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VmCheckpointsServiceListResponse{checkpoints: result}, nil
+}
+
+func (p *VmCheckpointsServiceListRequest) MustSend() *VmCheckpointsServiceListResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// The list of virtual machine checkpoints.
+//
+type VmCheckpointsServiceListResponse struct {
+	checkpoints *CheckpointSlice
+}
+
+func (p *VmCheckpointsServiceListResponse) Checkpoints() (*CheckpointSlice, bool) {
+	if p.checkpoints != nil {
+		return p.checkpoints, true
+	}
+	return nil, false
+}
+
+func (p *VmCheckpointsServiceListResponse) MustCheckpoints() *CheckpointSlice {
+	if p.checkpoints == nil {
+		panic("checkpoints in response does not exist")
+	}
+	return p.checkpoints
+}
+
+//
+// The list of virtual machine checkpoints.
+//
+func (p *VmCheckpointsService) List() *VmCheckpointsServiceListRequest {
+	return &VmCheckpointsServiceListRequest{VmCheckpointsService: p}
+}
+
+//
+// Returns a reference to the service that manages a specific VM checkpoint.
+//
+func (op *VmCheckpointsService) CheckpointService(id string) *VmCheckpointService {
+	return NewVmCheckpointService(op.connection, fmt.Sprintf("%s/%s", op.path, id))
+}
+
+//
+// Service locator method, returns individual service on which the URI is dispatched.
+//
+func (op *VmCheckpointsService) Service(path string) (Service, error) {
+	if path == "" {
+		return op, nil
+	}
+	index := strings.Index(path, "/")
+	if index == -1 {
+		return op.CheckpointService(path), nil
+	}
+	return op.CheckpointService(path[:index]).Service(path[index+1:])
+}
+
+func (op *VmCheckpointsService) String() string {
+	return fmt.Sprintf("VmCheckpointsService:%s", op.path)
 }
 
 //
@@ -80786,6 +81206,193 @@ func (op *VmWatchdogService) Service(path string) (Service, error) {
 
 func (op *VmWatchdogService) String() string {
 	return fmt.Sprintf("VmWatchdogService:%s", op.path)
+}
+
+//
+//
+type VmCheckpointDisksService struct {
+	BaseService
+}
+
+func NewVmCheckpointDisksService(connection *Connection, path string) *VmCheckpointDisksService {
+	var result VmCheckpointDisksService
+	result.connection = connection
+	result.path = path
+	return &result
+}
+
+//
+// Returns the list of disks in checkpoint.
+//
+type VmCheckpointDisksServiceListRequest struct {
+	VmCheckpointDisksService *VmCheckpointDisksService
+	header                   map[string]string
+	query                    map[string]string
+	follow                   *string
+	max                      *int64
+}
+
+func (p *VmCheckpointDisksServiceListRequest) Header(key, value string) *VmCheckpointDisksServiceListRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *VmCheckpointDisksServiceListRequest) Query(key, value string) *VmCheckpointDisksServiceListRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *VmCheckpointDisksServiceListRequest) Follow(follow string) *VmCheckpointDisksServiceListRequest {
+	p.follow = &follow
+	return p
+}
+
+func (p *VmCheckpointDisksServiceListRequest) Max(max int64) *VmCheckpointDisksServiceListRequest {
+	p.max = &max
+	return p
+}
+
+func (p *VmCheckpointDisksServiceListRequest) Send() (*VmCheckpointDisksServiceListResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.VmCheckpointDisksService.connection.URL(), p.VmCheckpointDisksService.path)
+	values := make(url.Values)
+	if p.follow != nil {
+		values["follow"] = []string{fmt.Sprintf("%v", *p.follow)}
+	}
+
+	if p.max != nil {
+		values["max"] = []string{fmt.Sprintf("%v", *p.max)}
+	}
+
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.VmCheckpointDisksService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.VmCheckpointDisksService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.VmCheckpointDisksService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.VmCheckpointDisksService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.VmCheckpointDisksService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLDiskReadMany(reader, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VmCheckpointDisksServiceListResponse{disks: result}, nil
+}
+
+func (p *VmCheckpointDisksServiceListRequest) MustSend() *VmCheckpointDisksServiceListResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Returns the list of disks in checkpoint.
+//
+type VmCheckpointDisksServiceListResponse struct {
+	disks *DiskSlice
+}
+
+func (p *VmCheckpointDisksServiceListResponse) Disks() (*DiskSlice, bool) {
+	if p.disks != nil {
+		return p.disks, true
+	}
+	return nil, false
+}
+
+func (p *VmCheckpointDisksServiceListResponse) MustDisks() *DiskSlice {
+	if p.disks == nil {
+		panic("disks in response does not exist")
+	}
+	return p.disks
+}
+
+//
+// Returns the list of disks in checkpoint.
+//
+func (p *VmCheckpointDisksService) List() *VmCheckpointDisksServiceListRequest {
+	return &VmCheckpointDisksServiceListRequest{VmCheckpointDisksService: p}
+}
+
+//
+// A reference to the service that manages a specific disk.
+//
+func (op *VmCheckpointDisksService) DiskService(id string) *VmCheckpointDiskService {
+	return NewVmCheckpointDiskService(op.connection, fmt.Sprintf("%s/%s", op.path, id))
+}
+
+//
+// Service locator method, returns individual service on which the URI is dispatched.
+//
+func (op *VmCheckpointDisksService) Service(path string) (Service, error) {
+	if path == "" {
+		return op, nil
+	}
+	index := strings.Index(path, "/")
+	if index == -1 {
+		return op.DiskService(path), nil
+	}
+	return op.DiskService(path[:index]).Service(path[index+1:])
+}
+
+func (op *VmCheckpointDisksService) String() string {
+	return fmt.Sprintf("VmCheckpointDisksService:%s", op.path)
 }
 
 //
@@ -100276,6 +100883,7 @@ func (p *VmService) Detach() *VmServiceDetachRequest {
 //   <filename>myvm.ova</filename>
 // </action>
 // ----
+// NOTE: Confirm that the export operation has completed before attempting any actions on the export domain.
 //
 type VmServiceExportRequest struct {
 	VmService        *VmService
@@ -100446,6 +101054,7 @@ func (p *VmServiceExportRequest) MustSend() *VmServiceExportResponse {
 //   <filename>myvm.ova</filename>
 // </action>
 // ----
+// NOTE: Confirm that the export operation has completed before attempting any actions on the export domain.
 //
 type VmServiceExportResponse struct {
 }
@@ -100486,6 +101095,7 @@ type VmServiceExportResponse struct {
 //   <filename>myvm.ova</filename>
 // </action>
 // ----
+// NOTE: Confirm that the export operation has completed before attempting any actions on the export domain.
 //
 func (p *VmService) Export() *VmServiceExportRequest {
 	return &VmServiceExportRequest{VmService: p}
@@ -100662,6 +101272,7 @@ type VmServiceGetRequest struct {
 	filter     *bool
 	follow     *string
 	nextRun    *bool
+	ovfAsOva   *bool
 }
 
 func (p *VmServiceGetRequest) Header(key, value string) *VmServiceGetRequest {
@@ -100700,6 +101311,11 @@ func (p *VmServiceGetRequest) NextRun(nextRun bool) *VmServiceGetRequest {
 	return p
 }
 
+func (p *VmServiceGetRequest) OvfAsOva(ovfAsOva bool) *VmServiceGetRequest {
+	p.ovfAsOva = &ovfAsOva
+	return p
+}
+
 func (p *VmServiceGetRequest) Send() (*VmServiceGetResponse, error) {
 	rawURL := fmt.Sprintf("%s%s", p.VmService.connection.URL(), p.VmService.path)
 	values := make(url.Values)
@@ -100717,6 +101333,10 @@ func (p *VmServiceGetRequest) Send() (*VmServiceGetResponse, error) {
 
 	if p.nextRun != nil {
 		values["next_run"] = []string{fmt.Sprintf("%v", *p.nextRun)}
+	}
+
+	if p.ovfAsOva != nil {
+		values["ovf_as_ova"] = []string{fmt.Sprintf("%v", *p.ovfAsOva)}
 	}
 
 	if p.query != nil {
@@ -103731,6 +104351,13 @@ func (op *VmService) CdromsService() *VmCdromsService {
 }
 
 //
+// List of checkpoints of this virtual machine.
+//
+func (op *VmService) CheckpointsService() *VmCheckpointsService {
+	return NewVmCheckpointsService(op.connection, fmt.Sprintf("%s/checkpoints", op.path))
+}
+
+//
 // List of disks attached to this virtual machine.
 //
 func (op *VmService) DiskAttachmentsService() *DiskAttachmentsService {
@@ -103842,6 +104469,12 @@ func (op *VmService) Service(path string) (Service, error) {
 	}
 	if strings.HasPrefix(path, "cdroms/") {
 		return op.CdromsService().Service(path[7:])
+	}
+	if path == "checkpoints" {
+		return op.CheckpointsService(), nil
+	}
+	if strings.HasPrefix(path, "checkpoints/") {
+		return op.CheckpointsService().Service(path[12:])
 	}
 	if path == "diskattachments" {
 		return op.DiskAttachmentsService(), nil
@@ -107816,6 +108449,7 @@ func (p *SnapshotService) Remove() *SnapshotServiceRemoveRequest {
 // ----
 // <action/>
 // ----
+// NOTE: Confirm that the commit operation is finished and the virtual machine is down before running the virtual machine.
 //
 type SnapshotServiceRestoreRequest struct {
 	SnapshotService *SnapshotService
@@ -107962,6 +108596,7 @@ func (p *SnapshotServiceRestoreRequest) MustSend() *SnapshotServiceRestoreRespon
 // ----
 // <action/>
 // ----
+// NOTE: Confirm that the commit operation is finished and the virtual machine is down before running the virtual machine.
 //
 type SnapshotServiceRestoreResponse struct {
 }
@@ -107979,6 +108614,7 @@ type SnapshotServiceRestoreResponse struct {
 // ----
 // <action/>
 // ----
+// NOTE: Confirm that the commit operation is finished and the virtual machine is down before running the virtual machine.
 //
 func (p *SnapshotService) Restore() *SnapshotServiceRestoreRequest {
 	return &SnapshotServiceRestoreRequest{SnapshotService: p}
@@ -110840,82 +111476,24 @@ func (op *StepsService) String() string {
 // The transfer can be resumed by calling <<services/image_transfer/methods/resume, resume>>
 // of the service that manages it.
 // If the session was successfully established - the returned transfer entity will
-// contain the <<types/image_transfer, proxy_url>> and <<types/image_transfer, signed_ticket>> attributes,
+// contain the <<types/image_transfer, transfer_url>> and <<types/image_transfer, proxy_url>> attributes,
 // which the client needs to use in order to transfer the required data. The client can choose whatever
 // technique and tool for sending the HTTPS request with the image's data.
-// - `proxy_url` is the address of a proxy server to the image, to do I/O to.
-// - `signed_ticket` is the content that needs to be added to the `Authentication`
-//    header in the HTTPS request, in order to perform a trusted communication.
-// For example, Python's HTTPSConnection can be used in order to perform a transfer,
-// so an `transfer_headers` dict is set for the upcoming transfer:
+// - `transfer_url` is the address of an imageio server running on one of the hypervisors.
+// - `proxy_url` is the address of an imageio proxy server that can be used if
+//   you cannot access transfer_url.
+// To transfer the image, it is recommended to use the imageio client python library.
 // [source,python]
 // ----
-// transfer_headers = {
-//    'Authorization' :  transfer.signed_ticket,
-// }
+// from ovirt_imageio import client
+// # Upload qcow2 image to virtual disk:
+// client.upload("disk.qcow2", transfer.transfer_url)
+// # Download virtual disk to qcow2 image:
+// client.download(transfer.transfer_url, "disk.qcow2")
 // ----
-// Using Python's `HTTPSConnection`, a new connection is established:
-// [source,python]
-// ----
-// # Extract the URI, port, and path from the transfer's proxy_url.
-// url = urlparse.urlparse(transfer.proxy_url)
-// # Create a new instance of the connection.
-// proxy_connection = HTTPSConnection(
-//    url.hostname,
-//    url.port,
-//    context=ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-// )
-// ----
-// For upload, the specific content range being sent must be noted in the `Content-Range` HTTPS
-// header. This can be used in order to split the transfer into several requests for
-// a more flexible process.
-// For doing that, the client will have to repeatedly extend the transfer session
-// to keep the channel open. Otherwise, the session will terminate and the transfer will
-// get into `paused_system` phase, and HTTPS requests to the server will be rejected.
-// E.g., the client can iterate on chunks of the file, and send them to the
-// proxy server while asking the service to extend the session:
-// [source,python]
-// ----
-// path = "/path/to/image"
-// MB_per_request = 32
-// with open(path, "rb") as disk:
-//    size = os.path.getsize(path)
-//    chunk_size = 1024*1024*MB_per_request
-//    pos = 0
-//    while (pos < size):
-//       transfer_service.extend()
-//       transfer_headers['Content-Range'] = "bytes %d-%d/%d" % (pos, min(pos + chunk_size, size)-1, size)
-//       proxy_connection.request(
-//          'PUT',
-//          url.path,
-//          disk.read(chunk_size),
-//          headers=transfer_headers
-//       )
-//       r = proxy_connection.getresponse()
-//       print r.status, r.reason, "Completed", "{:.0%}".format(pos/ float(size))
-//       pos += chunk_size
-// ----
-// Similarly, for a download transfer, a `Range` header must be sent, making the download process
-// more easily managed by downloading the disk in chunks.
-// E.g., the client will again iterate on chunks of the disk image, but this time he/she will download
-// it to a local file, rather than uploading its own file to the image:
-// [source,python]
-// ----
-// output_file = "/home/user/downloaded_image"
-// MiB_per_request = 32
-// chunk_size = 1024*1024*MiB_per_request
-// total = disk_size
-// with open(output_file, "wb") as disk:
-//    pos = 0
-//    while pos < total:
-//       transfer_service.extend()
-//       transfer_headers['Range'] = "bytes=%d-%d" %  (pos, min(total, pos + chunk_size) - 1)
-//       proxy_connection.request('GET', proxy_url.path, headers=transfer_headers)
-//       r = proxy_connection.getresponse()
-//       disk.write(r.read())
-//       print "Completed", "{:.0%}".format(pos/ float(total))
-//       pos += chunk_size
-// ----
+// You can also upload and download using imageio REST API. For more info
+// on this, see imageio API documentation:
+//     http://ovirt.github.io/ovirt-imageio/images.html
 // When finishing the transfer, the user should call
 // <<services/image_transfer/methods/finalize, finalize>>. This will make the
 // final adjustments and verifications for finishing the transfer process.
@@ -113071,17 +113649,332 @@ func (p *MacPoolService) Update() *MacPoolServiceUpdateRequest {
 }
 
 //
+// Returns a reference to the service that manages the permissions that are associated with the MacPool.
+//
+func (op *MacPoolService) PermissionsService() *AssignedPermissionsService {
+	return NewAssignedPermissionsService(op.connection, fmt.Sprintf("%s/permissions", op.path))
+}
+
+//
 // Service locator method, returns individual service on which the URI is dispatched.
 //
 func (op *MacPoolService) Service(path string) (Service, error) {
 	if path == "" {
 		return op, nil
 	}
+	if path == "permissions" {
+		return op.PermissionsService(), nil
+	}
+	if strings.HasPrefix(path, "permissions/") {
+		return op.PermissionsService().Service(path[12:])
+	}
 	return nil, fmt.Errorf("The path <%s> doesn't correspond to any service", path)
 }
 
 func (op *MacPoolService) String() string {
 	return fmt.Sprintf("MacPoolService:%s", op.path)
+}
+
+//
+// A service managing a checkpoint of a virtual machines.
+//
+type VmCheckpointService struct {
+	BaseService
+}
+
+func NewVmCheckpointService(connection *Connection, path string) *VmCheckpointService {
+	var result VmCheckpointService
+	result.connection = connection
+	result.path = path
+	return &result
+}
+
+//
+// Returns information about the virtual machine checkpoint.
+//
+type VmCheckpointServiceGetRequest struct {
+	VmCheckpointService *VmCheckpointService
+	header              map[string]string
+	query               map[string]string
+	follow              *string
+}
+
+func (p *VmCheckpointServiceGetRequest) Header(key, value string) *VmCheckpointServiceGetRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *VmCheckpointServiceGetRequest) Query(key, value string) *VmCheckpointServiceGetRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *VmCheckpointServiceGetRequest) Follow(follow string) *VmCheckpointServiceGetRequest {
+	p.follow = &follow
+	return p
+}
+
+func (p *VmCheckpointServiceGetRequest) Send() (*VmCheckpointServiceGetResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.VmCheckpointService.connection.URL(), p.VmCheckpointService.path)
+	values := make(url.Values)
+	if p.follow != nil {
+		values["follow"] = []string{fmt.Sprintf("%v", *p.follow)}
+	}
+
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.VmCheckpointService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.VmCheckpointService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.VmCheckpointService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.VmCheckpointService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.VmCheckpointService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLCheckpointReadOne(reader, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return &VmCheckpointServiceGetResponse{checkpoint: result}, nil
+}
+
+func (p *VmCheckpointServiceGetRequest) MustSend() *VmCheckpointServiceGetResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Returns information about the virtual machine checkpoint.
+//
+type VmCheckpointServiceGetResponse struct {
+	checkpoint *Checkpoint
+}
+
+func (p *VmCheckpointServiceGetResponse) Checkpoint() (*Checkpoint, bool) {
+	if p.checkpoint != nil {
+		return p.checkpoint, true
+	}
+	return nil, false
+}
+
+func (p *VmCheckpointServiceGetResponse) MustCheckpoint() *Checkpoint {
+	if p.checkpoint == nil {
+		panic("checkpoint in response does not exist")
+	}
+	return p.checkpoint
+}
+
+//
+// Returns information about the virtual machine checkpoint.
+//
+func (p *VmCheckpointService) Get() *VmCheckpointServiceGetRequest {
+	return &VmCheckpointServiceGetRequest{VmCheckpointService: p}
+}
+
+//
+// Remove the virtual machine checkpoint entity.
+// Remove the checkpoint from libvirt and the database.
+//
+type VmCheckpointServiceRemoveRequest struct {
+	VmCheckpointService *VmCheckpointService
+	header              map[string]string
+	query               map[string]string
+	async               *bool
+}
+
+func (p *VmCheckpointServiceRemoveRequest) Header(key, value string) *VmCheckpointServiceRemoveRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *VmCheckpointServiceRemoveRequest) Query(key, value string) *VmCheckpointServiceRemoveRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *VmCheckpointServiceRemoveRequest) Async(async bool) *VmCheckpointServiceRemoveRequest {
+	p.async = &async
+	return p
+}
+
+func (p *VmCheckpointServiceRemoveRequest) Send() (*VmCheckpointServiceRemoveResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.VmCheckpointService.connection.URL(), p.VmCheckpointService.path)
+	values := make(url.Values)
+	if p.async != nil {
+		values["async"] = []string{fmt.Sprintf("%v", *p.async)}
+	}
+
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("DELETE", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.VmCheckpointService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.VmCheckpointService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.VmCheckpointService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.VmCheckpointService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.VmCheckpointService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	_, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	return new(VmCheckpointServiceRemoveResponse), nil
+}
+
+func (p *VmCheckpointServiceRemoveRequest) MustSend() *VmCheckpointServiceRemoveResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Remove the virtual machine checkpoint entity.
+// Remove the checkpoint from libvirt and the database.
+//
+type VmCheckpointServiceRemoveResponse struct {
+}
+
+//
+// Remove the virtual machine checkpoint entity.
+// Remove the checkpoint from libvirt and the database.
+//
+func (p *VmCheckpointService) Remove() *VmCheckpointServiceRemoveRequest {
+	return &VmCheckpointServiceRemoveRequest{VmCheckpointService: p}
+}
+
+//
+// A reference to the service that lists the disks in checkpoint.
+//
+func (op *VmCheckpointService) DisksService() *VmCheckpointDisksService {
+	return NewVmCheckpointDisksService(op.connection, fmt.Sprintf("%s/disks", op.path))
+}
+
+//
+// Service locator method, returns individual service on which the URI is dispatched.
+//
+func (op *VmCheckpointService) Service(path string) (Service, error) {
+	if path == "" {
+		return op, nil
+	}
+	if path == "disks" {
+		return op.DisksService(), nil
+	}
+	if strings.HasPrefix(path, "disks/") {
+		return op.DisksService().Service(path[6:])
+	}
+	return nil, fmt.Errorf("The path <%s> doesn't correspond to any service", path)
+}
+
+func (op *VmCheckpointService) String() string {
+	return fmt.Sprintf("VmCheckpointService:%s", op.path)
 }
 
 //
@@ -120426,6 +121319,21 @@ func (p *DiskService) Update() *DiskServiceUpdateRequest {
 }
 
 //
+// Reference to the service that manages the DiskSnapshots.
+// For example, to list all disk snapshots under the disks resource '123':
+// ....
+// GET /ovirt-engine/api/disks/123/disksnapshots
+// ....
+// For example, to retrieve a specific disk snapshot '789' under the disk resource '123':
+// ....
+// GET /ovirt-engine/api/disks/123/disksnapshots/789
+// ....
+//
+func (op *DiskService) DiskSnapshotsService() *DiskSnapshotsService {
+	return NewDiskSnapshotsService(op.connection, fmt.Sprintf("%s/disksnapshots", op.path))
+}
+
+//
 // Reference to the service that manages the permissions assigned to the disk.
 //
 func (op *DiskService) PermissionsService() *AssignedPermissionsService {
@@ -120444,6 +121352,12 @@ func (op *DiskService) StatisticsService() *StatisticsService {
 func (op *DiskService) Service(path string) (Service, error) {
 	if path == "" {
 		return op, nil
+	}
+	if path == "disksnapshots" {
+		return op.DiskSnapshotsService(), nil
+	}
+	if strings.HasPrefix(path, "disksnapshots/") {
+		return op.DiskSnapshotsService().Service(path[14:])
 	}
 	if path == "permissions" {
 		return op.PermissionsService(), nil

--- a/vendor/github.com/ovirt/go-ovirt/types.go
+++ b/vendor/github.com/ovirt/go-ovirt/types.go
@@ -5144,6 +5144,7 @@ type MacPool struct {
 	description     *string
 	id              *string
 	name            *string
+	permissions     *PermissionSlice
 	ranges          *RangeSlice
 }
 
@@ -5261,6 +5262,24 @@ func (p *MacPool) MustName() string {
 	return *p.name
 }
 
+func (p *MacPool) SetPermissions(attr *PermissionSlice) {
+	p.permissions = attr
+}
+
+func (p *MacPool) Permissions() (*PermissionSlice, bool) {
+	if p.permissions != nil {
+		return p.permissions, true
+	}
+	return nil, false
+}
+
+func (p *MacPool) MustPermissions() *PermissionSlice {
+	if p.permissions == nil {
+		panic("the permissions must not be nil, please use Permissions() function instead")
+	}
+	return p.permissions
+}
+
 func (p *MacPool) SetRanges(attr *RangeSlice) {
 	p.ranges = attr
 }
@@ -5324,9 +5343,29 @@ func (p *VmPlacementPolicy) MustHosts() *HostSlice {
 
 type ProductInfo struct {
 	Struct
+	id      *string
 	name    *string
 	vendor  *string
 	version *Version
+}
+
+func (p *ProductInfo) SetId(attr string) {
+	p.id = &attr
+}
+
+func (p *ProductInfo) Id() (string, bool) {
+	if p.id != nil {
+		return *p.id, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *ProductInfo) MustId() string {
+	if p.id == nil {
+		panic("the id must not be nil, please use Id() function instead")
+	}
+	return *p.id
 }
 
 func (p *ProductInfo) SetName(attr string) {
@@ -7445,7 +7484,7 @@ type ImageTransfer struct {
 	name              *string
 	phase             *ImageTransferPhase
 	proxyUrl          *string
-	signedTicket      *string
+	shallow           *bool
 	snapshot          *DiskSnapshot
 	transferUrl       *string
 	transferred       *int64
@@ -7713,23 +7752,23 @@ func (p *ImageTransfer) MustProxyUrl() string {
 	return *p.proxyUrl
 }
 
-func (p *ImageTransfer) SetSignedTicket(attr string) {
-	p.signedTicket = &attr
+func (p *ImageTransfer) SetShallow(attr bool) {
+	p.shallow = &attr
 }
 
-func (p *ImageTransfer) SignedTicket() (string, bool) {
-	if p.signedTicket != nil {
-		return *p.signedTicket, true
+func (p *ImageTransfer) Shallow() (bool, bool) {
+	if p.shallow != nil {
+		return *p.shallow, true
 	}
-	var zero string
+	var zero bool
 	return zero, false
 }
 
-func (p *ImageTransfer) MustSignedTicket() string {
-	if p.signedTicket == nil {
-		panic("the signedTicket must not be nil, please use SignedTicket() function instead")
+func (p *ImageTransfer) MustShallow() bool {
+	if p.shallow == nil {
+		panic("the shallow must not be nil, please use Shallow() function instead")
 	}
-	return *p.signedTicket
+	return *p.shallow
 }
 
 func (p *ImageTransfer) SetSnapshot(attr *DiskSnapshot) {
@@ -22133,6 +22172,7 @@ type Network struct {
 	name                            *string
 	networkLabels                   *NetworkLabelSlice
 	permissions                     *PermissionSlice
+	portIsolation                   *bool
 	profileRequired                 *bool
 	qos                             *Qos
 	required                        *bool
@@ -22400,6 +22440,25 @@ func (p *Network) MustPermissions() *PermissionSlice {
 		panic("the permissions must not be nil, please use Permissions() function instead")
 	}
 	return p.permissions
+}
+
+func (p *Network) SetPortIsolation(attr bool) {
+	p.portIsolation = &attr
+}
+
+func (p *Network) PortIsolation() (bool, bool) {
+	if p.portIsolation != nil {
+		return *p.portIsolation, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Network) MustPortIsolation() bool {
+	if p.portIsolation == nil {
+		panic("the portIsolation must not be nil, please use PortIsolation() function instead")
+	}
+	return *p.portIsolation
 }
 
 func (p *Network) SetProfileRequired(attr bool) {
@@ -23349,6 +23408,168 @@ func (p *HardwareInformation) MustVersion() string {
 		panic("the version must not be nil, please use Version() function instead")
 	}
 	return *p.version
+}
+
+type Checkpoint struct {
+	Struct
+	comment      *string
+	creationDate *time.Time
+	description  *string
+	disks        *DiskSlice
+	id           *string
+	name         *string
+	parentId     *string
+	vm           *Vm
+}
+
+func (p *Checkpoint) SetComment(attr string) {
+	p.comment = &attr
+}
+
+func (p *Checkpoint) Comment() (string, bool) {
+	if p.comment != nil {
+		return *p.comment, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *Checkpoint) MustComment() string {
+	if p.comment == nil {
+		panic("the comment must not be nil, please use Comment() function instead")
+	}
+	return *p.comment
+}
+
+func (p *Checkpoint) SetCreationDate(attr time.Time) {
+	p.creationDate = &attr
+}
+
+func (p *Checkpoint) CreationDate() (time.Time, bool) {
+	if p.creationDate != nil {
+		return *p.creationDate, true
+	}
+	var zero time.Time
+	return zero, false
+}
+
+func (p *Checkpoint) MustCreationDate() time.Time {
+	if p.creationDate == nil {
+		panic("the creationDate must not be nil, please use CreationDate() function instead")
+	}
+	return *p.creationDate
+}
+
+func (p *Checkpoint) SetDescription(attr string) {
+	p.description = &attr
+}
+
+func (p *Checkpoint) Description() (string, bool) {
+	if p.description != nil {
+		return *p.description, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *Checkpoint) MustDescription() string {
+	if p.description == nil {
+		panic("the description must not be nil, please use Description() function instead")
+	}
+	return *p.description
+}
+
+func (p *Checkpoint) SetDisks(attr *DiskSlice) {
+	p.disks = attr
+}
+
+func (p *Checkpoint) Disks() (*DiskSlice, bool) {
+	if p.disks != nil {
+		return p.disks, true
+	}
+	return nil, false
+}
+
+func (p *Checkpoint) MustDisks() *DiskSlice {
+	if p.disks == nil {
+		panic("the disks must not be nil, please use Disks() function instead")
+	}
+	return p.disks
+}
+
+func (p *Checkpoint) SetId(attr string) {
+	p.id = &attr
+}
+
+func (p *Checkpoint) Id() (string, bool) {
+	if p.id != nil {
+		return *p.id, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *Checkpoint) MustId() string {
+	if p.id == nil {
+		panic("the id must not be nil, please use Id() function instead")
+	}
+	return *p.id
+}
+
+func (p *Checkpoint) SetName(attr string) {
+	p.name = &attr
+}
+
+func (p *Checkpoint) Name() (string, bool) {
+	if p.name != nil {
+		return *p.name, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *Checkpoint) MustName() string {
+	if p.name == nil {
+		panic("the name must not be nil, please use Name() function instead")
+	}
+	return *p.name
+}
+
+func (p *Checkpoint) SetParentId(attr string) {
+	p.parentId = &attr
+}
+
+func (p *Checkpoint) ParentId() (string, bool) {
+	if p.parentId != nil {
+		return *p.parentId, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *Checkpoint) MustParentId() string {
+	if p.parentId == nil {
+		panic("the parentId must not be nil, please use ParentId() function instead")
+	}
+	return *p.parentId
+}
+
+func (p *Checkpoint) SetVm(attr *Vm) {
+	p.vm = attr
+}
+
+func (p *Checkpoint) Vm() (*Vm, bool) {
+	if p.vm != nil {
+		return p.vm, true
+	}
+	return nil, false
+}
+
+func (p *Checkpoint) MustVm() *Vm {
+	if p.vm == nil {
+		panic("the vm must not be nil, please use Vm() function instead")
+	}
+	return p.vm
 }
 
 type Balance struct {
@@ -27744,6 +27965,8 @@ type DiskSnapshot struct {
 	description         *string
 	disk                *Disk
 	diskProfile         *DiskProfile
+	diskSnapshots       *DiskSnapshotSlice
+	externalDisk        *string
 	format              *DiskFormat
 	id                  *string
 	imageId             *string
@@ -27754,6 +27977,7 @@ type DiskSnapshot struct {
 	lunStorage          *HostStorage
 	name                *string
 	openstackVolumeType *OpenStackVolumeType
+	parent              *DiskSnapshot
 	permissions         *PermissionSlice
 	propagateErrors     *bool
 	provisionedSize     *int64
@@ -27965,6 +28189,43 @@ func (p *DiskSnapshot) MustDiskProfile() *DiskProfile {
 	return p.diskProfile
 }
 
+func (p *DiskSnapshot) SetDiskSnapshots(attr *DiskSnapshotSlice) {
+	p.diskSnapshots = attr
+}
+
+func (p *DiskSnapshot) DiskSnapshots() (*DiskSnapshotSlice, bool) {
+	if p.diskSnapshots != nil {
+		return p.diskSnapshots, true
+	}
+	return nil, false
+}
+
+func (p *DiskSnapshot) MustDiskSnapshots() *DiskSnapshotSlice {
+	if p.diskSnapshots == nil {
+		panic("the diskSnapshots must not be nil, please use DiskSnapshots() function instead")
+	}
+	return p.diskSnapshots
+}
+
+func (p *DiskSnapshot) SetExternalDisk(attr string) {
+	p.externalDisk = &attr
+}
+
+func (p *DiskSnapshot) ExternalDisk() (string, bool) {
+	if p.externalDisk != nil {
+		return *p.externalDisk, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *DiskSnapshot) MustExternalDisk() string {
+	if p.externalDisk == nil {
+		panic("the externalDisk must not be nil, please use ExternalDisk() function instead")
+	}
+	return *p.externalDisk
+}
+
 func (p *DiskSnapshot) SetFormat(attr DiskFormat) {
 	p.format = &attr
 }
@@ -28150,6 +28411,24 @@ func (p *DiskSnapshot) MustOpenstackVolumeType() *OpenStackVolumeType {
 		panic("the openstackVolumeType must not be nil, please use OpenstackVolumeType() function instead")
 	}
 	return p.openstackVolumeType
+}
+
+func (p *DiskSnapshot) SetParent(attr *DiskSnapshot) {
+	p.parent = attr
+}
+
+func (p *DiskSnapshot) Parent() (*DiskSnapshot, bool) {
+	if p.parent != nil {
+		return p.parent, true
+	}
+	return nil, false
+}
+
+func (p *DiskSnapshot) MustParent() *DiskSnapshot {
+	if p.parent == nil {
+		panic("the parent must not be nil, please use Parent() function instead")
+	}
+	return p.parent
 }
 
 func (p *DiskSnapshot) SetPermissions(attr *PermissionSlice) {
@@ -29112,6 +29391,8 @@ type Disk struct {
 	contentType         *DiskContentType
 	description         *string
 	diskProfile         *DiskProfile
+	diskSnapshots       *DiskSnapshotSlice
+	externalDisk        *string
 	format              *DiskFormat
 	id                  *string
 	imageId             *string
@@ -29313,6 +29594,43 @@ func (p *Disk) MustDiskProfile() *DiskProfile {
 		panic("the diskProfile must not be nil, please use DiskProfile() function instead")
 	}
 	return p.diskProfile
+}
+
+func (p *Disk) SetDiskSnapshots(attr *DiskSnapshotSlice) {
+	p.diskSnapshots = attr
+}
+
+func (p *Disk) DiskSnapshots() (*DiskSnapshotSlice, bool) {
+	if p.diskSnapshots != nil {
+		return p.diskSnapshots, true
+	}
+	return nil, false
+}
+
+func (p *Disk) MustDiskSnapshots() *DiskSnapshotSlice {
+	if p.diskSnapshots == nil {
+		panic("the diskSnapshots must not be nil, please use DiskSnapshots() function instead")
+	}
+	return p.diskSnapshots
+}
+
+func (p *Disk) SetExternalDisk(attr string) {
+	p.externalDisk = &attr
+}
+
+func (p *Disk) ExternalDisk() (string, bool) {
+	if p.externalDisk != nil {
+		return *p.externalDisk, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *Disk) MustExternalDisk() string {
+	if p.externalDisk == nil {
+		panic("the externalDisk must not be nil, please use ExternalDisk() function instead")
+	}
+	return *p.externalDisk
 }
 
 func (p *Disk) SetFormat(attr DiskFormat) {
@@ -30799,6 +31117,7 @@ type Cluster struct {
 	tunnelMigration                  *bool
 	version                          *Version
 	virtService                      *bool
+	vncEncryption                    *bool
 }
 
 func (p *Cluster) SetAffinityGroups(attr *AffinityGroupSlice) {
@@ -31610,6 +31929,25 @@ func (p *Cluster) MustVirtService() bool {
 		panic("the virtService must not be nil, please use VirtService() function instead")
 	}
 	return *p.virtService
+}
+
+func (p *Cluster) SetVncEncryption(attr bool) {
+	p.vncEncryption = &attr
+}
+
+func (p *Cluster) VncEncryption() (bool, bool) {
+	if p.vncEncryption != nil {
+		return *p.vncEncryption, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Cluster) MustVncEncryption() bool {
+	if p.vncEncryption == nil {
+		panic("the vncEncryption must not be nil, please use VncEncryption() function instead")
+	}
+	return *p.vncEncryption
 }
 
 type GlusterBrickMemoryInfo struct {
@@ -36907,6 +37245,7 @@ type Host struct {
 	port                                  *int64
 	powerManagement                       *PowerManagement
 	protocol                              *HostProtocol
+	reinstallationRequired                *bool
 	rootPassword                          *string
 	seLinux                               *SeLinux
 	spm                                   *Spm
@@ -37623,6 +37962,25 @@ func (p *Host) MustProtocol() HostProtocol {
 		panic("the protocol must not be nil, please use Protocol() function instead")
 	}
 	return *p.protocol
+}
+
+func (p *Host) SetReinstallationRequired(attr bool) {
+	p.reinstallationRequired = &attr
+}
+
+func (p *Host) ReinstallationRequired() (bool, bool) {
+	if p.reinstallationRequired != nil {
+		return *p.reinstallationRequired, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Host) MustReinstallationRequired() bool {
+	if p.reinstallationRequired == nil {
+		panic("the reinstallationRequired must not be nil, please use ReinstallationRequired() function instead")
+	}
+	return *p.reinstallationRequired
 }
 
 func (p *Host) SetRootPassword(attr string) {
@@ -38775,6 +39133,7 @@ type Action struct {
 	async                          *bool
 	attachment                     *DiskAttachment
 	authorizedKey                  *AuthorizedKey
+	autoPinningPolicy              *AutoPinningPolicy
 	bricks                         *GlusterBrickSlice
 	certificates                   *CertificateSlice
 	checkConnectivity              *bool
@@ -38955,6 +39314,25 @@ func (p *Action) MustAuthorizedKey() *AuthorizedKey {
 		panic("the authorizedKey must not be nil, please use AuthorizedKey() function instead")
 	}
 	return p.authorizedKey
+}
+
+func (p *Action) SetAutoPinningPolicy(attr AutoPinningPolicy) {
+	p.autoPinningPolicy = &attr
+}
+
+func (p *Action) AutoPinningPolicy() (AutoPinningPolicy, bool) {
+	if p.autoPinningPolicy != nil {
+		return *p.autoPinningPolicy, true
+	}
+	var zero AutoPinningPolicy
+	return zero, false
+}
+
+func (p *Action) MustAutoPinningPolicy() AutoPinningPolicy {
+	if p.autoPinningPolicy == nil {
+		panic("the autoPinningPolicy must not be nil, please use AutoPinningPolicy() function instead")
+	}
+	return *p.autoPinningPolicy
 }
 
 func (p *Action) SetBricks(attr *GlusterBrickSlice) {
@@ -43853,6 +44231,30 @@ func (op *HardwareInformationSlice) Slice() []*HardwareInformation {
 }
 
 func (op *HardwareInformationSlice) SetSlice(slice []*HardwareInformation) {
+	op.slice = slice
+}
+
+type CheckpointSlice struct {
+	href  *string
+	slice []*Checkpoint
+}
+
+func (op *CheckpointSlice) Href() (string, bool) {
+	if op.href == nil {
+		return "", false
+	}
+	return *op.href, true
+}
+
+func (op *CheckpointSlice) SetHref(href string) {
+	op.href = &href
+}
+
+func (op *CheckpointSlice) Slice() []*Checkpoint {
+	return op.slice
+}
+
+func (op *CheckpointSlice) SetSlice(slice []*Checkpoint) {
 	op.slice = slice
 }
 
@@ -51151,6 +51553,47 @@ func (builder *MacPoolBuilder) Name(attr string) *MacPoolBuilder {
 	return builder
 }
 
+func (builder *MacPoolBuilder) Permissions(attr *PermissionSlice) *MacPoolBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.macPool.SetPermissions(attr)
+	return builder
+}
+
+func (builder *MacPoolBuilder) PermissionsOfAny(anys ...*Permission) *MacPoolBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if builder.macPool.permissions == nil {
+		builder.macPool.permissions = new(PermissionSlice)
+	}
+	builder.macPool.permissions.slice = append(builder.macPool.permissions.slice, anys...)
+	return builder
+}
+
+func (builder *MacPoolBuilder) PermissionsBuilderOfAny(anyBuilders ...PermissionBuilder) *MacPoolBuilder {
+	if builder.err != nil || len(anyBuilders) == 0 {
+		return builder
+	}
+
+	for _, b := range anyBuilders {
+		if b.err != nil {
+			builder.err = b.err
+			return builder
+		}
+		attr, err := b.Build()
+		if err != nil {
+			builder.err = b.err
+			return builder
+		}
+		builder.PermissionsOfAny(attr)
+	}
+	return builder
+}
+
 func (builder *MacPoolBuilder) Ranges(attr *RangeSlice) *MacPoolBuilder {
 	if builder.err != nil {
 		return builder
@@ -51304,6 +51747,15 @@ type ProductInfoBuilder struct {
 
 func NewProductInfoBuilder() *ProductInfoBuilder {
 	return &ProductInfoBuilder{productInfo: &ProductInfo{}, err: nil}
+}
+
+func (builder *ProductInfoBuilder) Id(attr string) *ProductInfoBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.productInfo.SetId(attr)
+	return builder
 }
 
 func (builder *ProductInfoBuilder) Name(attr string) *ProductInfoBuilder {
@@ -53482,12 +53934,12 @@ func (builder *ImageTransferBuilder) ProxyUrl(attr string) *ImageTransferBuilder
 	return builder
 }
 
-func (builder *ImageTransferBuilder) SignedTicket(attr string) *ImageTransferBuilder {
+func (builder *ImageTransferBuilder) Shallow(attr bool) *ImageTransferBuilder {
 	if builder.err != nil {
 		return builder
 	}
 
-	builder.imageTransfer.SetSignedTicket(attr)
+	builder.imageTransfer.SetShallow(attr)
 	return builder
 }
 
@@ -68847,6 +69299,15 @@ func (builder *NetworkBuilder) PermissionsBuilderOfAny(anyBuilders ...Permission
 	return builder
 }
 
+func (builder *NetworkBuilder) PortIsolation(attr bool) *NetworkBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.network.SetPortIsolation(attr)
+	return builder
+}
+
 func (builder *NetworkBuilder) ProfileRequired(attr bool) *NetworkBuilder {
 	if builder.err != nil {
 		return builder
@@ -69883,6 +70344,159 @@ func (builder *HardwareInformationBuilder) MustBuild() *HardwareInformation {
 		panic(fmt.Sprintf("Failed to build HardwareInformation instance, reason: %v", builder.err))
 	}
 	return builder.hardwareInformation
+}
+
+type CheckpointBuilder struct {
+	checkpoint *Checkpoint
+	err        error
+}
+
+func NewCheckpointBuilder() *CheckpointBuilder {
+	return &CheckpointBuilder{checkpoint: &Checkpoint{}, err: nil}
+}
+
+func (builder *CheckpointBuilder) Comment(attr string) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetComment(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) CreationDate(attr time.Time) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetCreationDate(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) Description(attr string) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetDescription(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) Disks(attr *DiskSlice) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetDisks(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) DisksOfAny(anys ...*Disk) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if builder.checkpoint.disks == nil {
+		builder.checkpoint.disks = new(DiskSlice)
+	}
+	builder.checkpoint.disks.slice = append(builder.checkpoint.disks.slice, anys...)
+	return builder
+}
+
+func (builder *CheckpointBuilder) DisksBuilderOfAny(anyBuilders ...DiskBuilder) *CheckpointBuilder {
+	if builder.err != nil || len(anyBuilders) == 0 {
+		return builder
+	}
+
+	for _, b := range anyBuilders {
+		if b.err != nil {
+			builder.err = b.err
+			return builder
+		}
+		attr, err := b.Build()
+		if err != nil {
+			builder.err = b.err
+			return builder
+		}
+		builder.DisksOfAny(attr)
+	}
+	return builder
+}
+
+func (builder *CheckpointBuilder) Id(attr string) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetId(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) Name(attr string) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetName(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) ParentId(attr string) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetParentId(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) Vm(attr *Vm) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetVm(attr)
+	return builder
+}
+
+func (builder *CheckpointBuilder) VmBuilder(attrBuilder *VmBuilder) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if attrBuilder.err != nil {
+		builder.err = attrBuilder.err
+		return builder
+	}
+	attr, err := attrBuilder.Build()
+	if err != nil {
+		builder.err = err
+		return builder
+	}
+	return builder.Vm(attr)
+}
+
+func (builder *CheckpointBuilder) Href(href string) *CheckpointBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.checkpoint.SetHref(href)
+	return builder
+}
+
+func (builder *CheckpointBuilder) Build() (*Checkpoint, error) {
+	if builder.err != nil {
+		return nil, builder.err
+	}
+	return builder.checkpoint, nil
+}
+
+func (builder *CheckpointBuilder) MustBuild() *Checkpoint {
+	if builder.err != nil {
+		panic(fmt.Sprintf("Failed to build Checkpoint instance, reason: %v", builder.err))
+	}
+	return builder.checkpoint
 }
 
 type BalanceBuilder struct {
@@ -74178,6 +74792,56 @@ func (builder *DiskSnapshotBuilder) DiskProfileBuilder(attrBuilder *DiskProfileB
 	return builder.DiskProfile(attr)
 }
 
+func (builder *DiskSnapshotBuilder) DiskSnapshots(attr *DiskSnapshotSlice) *DiskSnapshotBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.diskSnapshot.SetDiskSnapshots(attr)
+	return builder
+}
+
+func (builder *DiskSnapshotBuilder) DiskSnapshotsOfAny(anys ...*DiskSnapshot) *DiskSnapshotBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if builder.diskSnapshot.diskSnapshots == nil {
+		builder.diskSnapshot.diskSnapshots = new(DiskSnapshotSlice)
+	}
+	builder.diskSnapshot.diskSnapshots.slice = append(builder.diskSnapshot.diskSnapshots.slice, anys...)
+	return builder
+}
+
+func (builder *DiskSnapshotBuilder) DiskSnapshotsBuilderOfAny(anyBuilders ...DiskSnapshotBuilder) *DiskSnapshotBuilder {
+	if builder.err != nil || len(anyBuilders) == 0 {
+		return builder
+	}
+
+	for _, b := range anyBuilders {
+		if b.err != nil {
+			builder.err = b.err
+			return builder
+		}
+		attr, err := b.Build()
+		if err != nil {
+			builder.err = b.err
+			return builder
+		}
+		builder.DiskSnapshotsOfAny(attr)
+	}
+	return builder
+}
+
+func (builder *DiskSnapshotBuilder) ExternalDisk(attr string) *DiskSnapshotBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.diskSnapshot.SetExternalDisk(attr)
+	return builder
+}
+
 func (builder *DiskSnapshotBuilder) Format(attr DiskFormat) *DiskSnapshotBuilder {
 	if builder.err != nil {
 		return builder
@@ -74317,6 +74981,32 @@ func (builder *DiskSnapshotBuilder) OpenstackVolumeTypeBuilder(attrBuilder *Open
 		return builder
 	}
 	return builder.OpenstackVolumeType(attr)
+}
+
+func (builder *DiskSnapshotBuilder) Parent(attr *DiskSnapshot) *DiskSnapshotBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.diskSnapshot.SetParent(attr)
+	return builder
+}
+
+func (builder *DiskSnapshotBuilder) ParentBuilder(attrBuilder *DiskSnapshotBuilder) *DiskSnapshotBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if attrBuilder.err != nil {
+		builder.err = attrBuilder.err
+		return builder
+	}
+	attr, err := attrBuilder.Build()
+	if err != nil {
+		builder.err = err
+		return builder
+	}
+	return builder.Parent(attr)
 }
 
 func (builder *DiskSnapshotBuilder) Permissions(attr *PermissionSlice) *DiskSnapshotBuilder {
@@ -75499,6 +76189,56 @@ func (builder *DiskBuilder) DiskProfileBuilder(attrBuilder *DiskProfileBuilder) 
 		return builder
 	}
 	return builder.DiskProfile(attr)
+}
+
+func (builder *DiskBuilder) DiskSnapshots(attr *DiskSnapshotSlice) *DiskBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.disk.SetDiskSnapshots(attr)
+	return builder
+}
+
+func (builder *DiskBuilder) DiskSnapshotsOfAny(anys ...*DiskSnapshot) *DiskBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if builder.disk.diskSnapshots == nil {
+		builder.disk.diskSnapshots = new(DiskSnapshotSlice)
+	}
+	builder.disk.diskSnapshots.slice = append(builder.disk.diskSnapshots.slice, anys...)
+	return builder
+}
+
+func (builder *DiskBuilder) DiskSnapshotsBuilderOfAny(anyBuilders ...DiskSnapshotBuilder) *DiskBuilder {
+	if builder.err != nil || len(anyBuilders) == 0 {
+		return builder
+	}
+
+	for _, b := range anyBuilders {
+		if b.err != nil {
+			builder.err = b.err
+			return builder
+		}
+		attr, err := b.Build()
+		if err != nil {
+			builder.err = b.err
+			return builder
+		}
+		builder.DiskSnapshotsOfAny(attr)
+	}
+	return builder
+}
+
+func (builder *DiskBuilder) ExternalDisk(attr string) *DiskBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.disk.SetExternalDisk(attr)
+	return builder
 }
 
 func (builder *DiskBuilder) Format(attr DiskFormat) *DiskBuilder {
@@ -77902,6 +78642,15 @@ func (builder *ClusterBuilder) VirtService(attr bool) *ClusterBuilder {
 	}
 
 	builder.cluster.SetVirtService(attr)
+	return builder
+}
+
+func (builder *ClusterBuilder) VncEncryption(attr bool) *ClusterBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.cluster.SetVncEncryption(attr)
 	return builder
 }
 
@@ -84397,6 +85146,15 @@ func (builder *HostBuilder) Protocol(attr HostProtocol) *HostBuilder {
 	return builder
 }
 
+func (builder *HostBuilder) ReinstallationRequired(attr bool) *HostBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.host.SetReinstallationRequired(attr)
+	return builder
+}
+
 func (builder *HostBuilder) RootPassword(attr string) *HostBuilder {
 	if builder.err != nil {
 		return builder
@@ -85893,6 +86651,15 @@ func (builder *ActionBuilder) AuthorizedKeyBuilder(attrBuilder *AuthorizedKeyBui
 		return builder
 	}
 	return builder.AuthorizedKey(attr)
+}
+
+func (builder *ActionBuilder) AutoPinningPolicy(attr AutoPinningPolicy) *ActionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.action.SetAutoPinningPolicy(attr)
+	return builder
 }
 
 func (builder *ActionBuilder) Bricks(attr *GlusterBrickSlice) *ActionBuilder {
@@ -88043,6 +88810,14 @@ const (
 	QOSTYPE_HOSTNETWORK QosType = "hostnetwork"
 	QOSTYPE_NETWORK     QosType = "network"
 	QOSTYPE_STORAGE     QosType = "storage"
+)
+
+type AutoPinningPolicy string
+
+const (
+	AUTOPINNINGPOLICY_ADJUST   AutoPinningPolicy = "adjust"
+	AUTOPINNINGPOLICY_DISABLED AutoPinningPolicy = "disabled"
+	AUTOPINNINGPOLICY_EXISTING AutoPinningPolicy = "existing"
 )
 
 type StepEnum string

--- a/vendor/github.com/ovirt/go-ovirt/writers.go
+++ b/vendor/github.com/ovirt/go-ovirt/writers.go
@@ -1634,6 +1634,9 @@ func XMLMacPoolWriteOne(writer *XMLWriter, object *MacPool, tag string) error {
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
 	}
+	if r, ok := object.Permissions(); ok {
+		XMLPermissionWriteMany(writer, r, "permissions", "permission")
+	}
 	if r, ok := object.Ranges(); ok {
 		XMLRangeWriteMany(writer, r, "ranges", "range")
 	}
@@ -1696,7 +1699,14 @@ func XMLProductInfoWriteOne(writer *XMLWriter, object *ProductInfo, tag string) 
 	if tag == "" {
 		tag = "product_info"
 	}
-	writer.WriteStart("", tag, nil)
+	var attrs map[string]string
+	if r, ok := object.Id(); ok {
+		if attrs == nil {
+			attrs = make(map[string]string)
+		}
+		attrs["id"] = r
+	}
+	writer.WriteStart("", tag, attrs)
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
 	}
@@ -2457,8 +2467,8 @@ func XMLImageTransferWriteOne(writer *XMLWriter, object *ImageTransfer, tag stri
 	if r, ok := object.ProxyUrl(); ok {
 		writer.WriteCharacter("proxy_url", r)
 	}
-	if r, ok := object.SignedTicket(); ok {
-		writer.WriteCharacter("signed_ticket", r)
+	if r, ok := object.Shallow(); ok {
+		writer.WriteBool("shallow", r)
 	}
 	if r, ok := object.Snapshot(); ok {
 		XMLDiskSnapshotWriteOne(writer, r, "snapshot")
@@ -7227,6 +7237,9 @@ func XMLNetworkWriteOne(writer *XMLWriter, object *Network, tag string) error {
 	if r, ok := object.Permissions(); ok {
 		XMLPermissionWriteMany(writer, r, "permissions", "permission")
 	}
+	if r, ok := object.PortIsolation(); ok {
+		writer.WriteBool("port_isolation", r)
+	}
 	if r, ok := object.ProfileRequired(); ok {
 		writer.WriteBool("profile_required", r)
 	}
@@ -7501,6 +7514,61 @@ func XMLHardwareInformationWriteMany(writer *XMLWriter, structSlice *HardwareInf
 	writer.WriteStart("", plural, nil)
 	for _, o := range structSlice.Slice() {
 		XMLHardwareInformationWriteOne(writer, o, singular)
+	}
+	writer.WriteEnd(plural)
+	return nil
+}
+
+func XMLCheckpointWriteOne(writer *XMLWriter, object *Checkpoint, tag string) error {
+	if object == nil {
+		return fmt.Errorf("input object pointer is nil")
+	}
+	if tag == "" {
+		tag = "checkpoint"
+	}
+	var attrs map[string]string
+	if r, ok := object.Id(); ok {
+		if attrs == nil {
+			attrs = make(map[string]string)
+		}
+		attrs["id"] = r
+	}
+	writer.WriteStart("", tag, attrs)
+	if r, ok := object.Comment(); ok {
+		writer.WriteCharacter("comment", r)
+	}
+	if r, ok := object.CreationDate(); ok {
+		writer.WriteDate("creation_date", r)
+	}
+	if r, ok := object.Description(); ok {
+		writer.WriteCharacter("description", r)
+	}
+	if r, ok := object.Disks(); ok {
+		XMLDiskWriteMany(writer, r, "disks", "disk")
+	}
+	if r, ok := object.Name(); ok {
+		writer.WriteCharacter("name", r)
+	}
+	if r, ok := object.ParentId(); ok {
+		writer.WriteCharacter("parent_id", r)
+	}
+	if r, ok := object.Vm(); ok {
+		XMLVmWriteOne(writer, r, "vm")
+	}
+	writer.WriteEnd(tag)
+	return nil
+}
+
+func XMLCheckpointWriteMany(writer *XMLWriter, structSlice *CheckpointSlice, plural, singular string) error {
+	if plural == "" {
+		plural = "checkpoints"
+	}
+	if singular == "" {
+		singular = "checkpoint"
+	}
+	writer.WriteStart("", plural, nil)
+	for _, o := range structSlice.Slice() {
+		XMLCheckpointWriteOne(writer, o, singular)
 	}
 	writer.WriteEnd(plural)
 	return nil
@@ -8870,6 +8938,12 @@ func XMLDiskSnapshotWriteOne(writer *XMLWriter, object *DiskSnapshot, tag string
 	if r, ok := object.DiskProfile(); ok {
 		XMLDiskProfileWriteOne(writer, r, "disk_profile")
 	}
+	if r, ok := object.DiskSnapshots(); ok {
+		XMLDiskSnapshotWriteMany(writer, r, "disk_snapshots", "disk_snapshot")
+	}
+	if r, ok := object.ExternalDisk(); ok {
+		writer.WriteCharacter("external_disk", r)
+	}
 	if r, ok := object.Format(); ok {
 		XMLDiskFormatWriteOne(writer, r, "format")
 	}
@@ -8896,6 +8970,9 @@ func XMLDiskSnapshotWriteOne(writer *XMLWriter, object *DiskSnapshot, tag string
 	}
 	if r, ok := object.OpenstackVolumeType(); ok {
 		XMLOpenStackVolumeTypeWriteOne(writer, r, "openstack_volume_type")
+	}
+	if r, ok := object.Parent(); ok {
+		XMLDiskSnapshotWriteOne(writer, r, "parent")
 	}
 	if r, ok := object.Permissions(); ok {
 		XMLPermissionWriteMany(writer, r, "permissions", "permission")
@@ -9298,6 +9375,12 @@ func XMLDiskWriteOne(writer *XMLWriter, object *Disk, tag string) error {
 	}
 	if r, ok := object.DiskProfile(); ok {
 		XMLDiskProfileWriteOne(writer, r, "disk_profile")
+	}
+	if r, ok := object.DiskSnapshots(); ok {
+		XMLDiskSnapshotWriteMany(writer, r, "disk_snapshots", "disk_snapshot")
+	}
+	if r, ok := object.ExternalDisk(); ok {
+		writer.WriteCharacter("external_disk", r)
 	}
 	if r, ok := object.Format(); ok {
 		XMLDiskFormatWriteOne(writer, r, "format")
@@ -9909,6 +9992,9 @@ func XMLClusterWriteOne(writer *XMLWriter, object *Cluster, tag string) error {
 	}
 	if r, ok := object.VirtService(); ok {
 		writer.WriteBool("virt_service", r)
+	}
+	if r, ok := object.VncEncryption(); ok {
+		writer.WriteBool("vnc_encryption", r)
 	}
 	writer.WriteEnd(tag)
 	return nil
@@ -11590,6 +11676,9 @@ func XMLHostWriteOne(writer *XMLWriter, object *Host, tag string) error {
 	if r, ok := object.Protocol(); ok {
 		XMLHostProtocolWriteOne(writer, r, "protocol")
 	}
+	if r, ok := object.ReinstallationRequired(); ok {
+		writer.WriteBool("reinstallation_required", r)
+	}
 	if r, ok := object.RootPassword(); ok {
 		writer.WriteCharacter("root_password", r)
 	}
@@ -12017,6 +12106,9 @@ func XMLActionWriteOne(writer *XMLWriter, object *Action, tag string) error {
 	}
 	if r, ok := object.AuthorizedKey(); ok {
 		XMLAuthorizedKeyWriteOne(writer, r, "authorized_key")
+	}
+	if r, ok := object.AutoPinningPolicy(); ok {
+		XMLAutoPinningPolicyWriteOne(writer, r, "auto_pinning_policy")
 	}
 	if r, ok := object.Bricks(); ok {
 		XMLGlusterBrickWriteMany(writer, r, "bricks", "brick")
@@ -13056,6 +13148,28 @@ func XMLQosTypeWriteMany(writer *XMLWriter, enums []QosType, plural, singular st
 	}
 	if singular == "" {
 		singular = "qos_type"
+	}
+	writer.WriteStart("", plural, nil)
+	for _, e := range enums {
+		writer.WriteCharacter(singular, string(e))
+	}
+	writer.WriteEnd(plural)
+	return nil
+}
+
+func XMLAutoPinningPolicyWriteOne(writer *XMLWriter, enum AutoPinningPolicy, tag string) {
+	if tag == "" {
+		tag = "auto_pinning_policy"
+	}
+	writer.WriteCharacter(tag, string(enum))
+}
+
+func XMLAutoPinningPolicyWriteMany(writer *XMLWriter, enums []AutoPinningPolicy, plural, singular string) error {
+	if plural == "" {
+		plural = "auto_pinning_policies"
+	}
+	if singular == "" {
+		singular = "auto_pinning_policy"
 	}
 	writer.WriteStart("", plural, nil)
 	for _, e := range enums {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,7 +181,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/v1helpers
 github.com/openshift/library-go/pkg/serviceability
-# github.com/ovirt/go-ovirt v0.0.0-20200709024803-dab75bb9273d
+# github.com/ovirt/go-ovirt v0.0.0-20201023070830-77e357c438d5
 github.com/ovirt/go-ovirt
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors


### PR DESCRIPTION
bumped go-ovirt version to the latest to consume:

oVirt/ovirt-engine-sdk-go#217
oVirt/ovirt-engine-sdk-go#215

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>