### PR TITLE
Bug 1918395: increase livenessProbe period

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -114,7 +114,7 @@ spec:
               port: healthz
             initialDelaySeconds: 10
             timeoutSeconds: 3
-            periodSeconds: 10
+            periodSeconds: 30
             failureThreshold: 5
           resources:
             requests:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -405,7 +405,7 @@ spec:
               port: healthz
             initialDelaySeconds: 10
             timeoutSeconds: 3
-            periodSeconds: 10
+            periodSeconds: 30
             failureThreshold: 5
           resources:
             requests:


### PR DESCRIPTION
As benny stated on [1] the csi-driver livenessProbe periodSeconds field was intended to be once each 30s[2], it was lost in the migration to a second level operator(storage).
We should increase that field

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1918287#c1
[2] https://github.com/oVirt/csi-driver/commit/efb64526378d20fca0039b61aa421b29321e380e#diff-4b761eacd68a8a2fb6f81f7c9f0e4c22b0c707238a37d7325f0bf84d211586adR103

This is causing the logs to fill up and increase there size.