### PR TITLE
Cleanup: Remove serviceName from controller manifest

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -9,7 +9,6 @@ spec:
   selector:
     matchLabels:
       app: ovirt-csi-driver-controller
-  serviceName: ovirt-csi-driver-controller
   replicas: 1
   template:
     metadata:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -81,7 +81,6 @@ spec:
   selector:
     matchLabels:
       app: ovirt-csi-driver-controller
-  serviceName: ovirt-csi-driver-controller
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Deployment spec doesn't support this property, so we should remove it.