### PR TITLE
Bug 1933184: Fix maxUnavailable value to 10%

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -12,7 +12,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -302,7 +302,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Bug 1933184 wants us to have more than 1% to speed up upgrades.