### PR TITLE
WIP: Bug 1969960: Added support for the ovirt_ca_bundle field

### DIFF
--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -32,6 +32,7 @@ func newOvirtConnection() (*ovirtsdk.Connection, error) {
 		Username(ovirtConfig.Username).
 		Password(ovirtConfig.Password).
 		CAFile(ovirtConfig.CAFile).
+		CACert(ovirtConfig.CABundle).
 		Insecure(ovirtConfig.Insecure).
 		Build()
 	if err != nil {
@@ -65,6 +66,7 @@ type Config struct {
 	Username string `yaml:"ovirt_username"`
 	Password string `yaml:"ovirt_password"`
 	CAFile   string `yaml:"ovirt_cafile,omitempty"`
+	CABundle []byte `yaml:"ovirt_ca_bundle,omitempty"`
 	Insecure bool   `yaml:"ovirt_insecure,omitempty"`
 }
 


### PR DESCRIPTION
This PR fixes BZ 1969960 by adding support for the `ovirt_ca_bundle` field. This PR has not been tested yet.