### PR TITLE
Bug 1933028: Wraps config.Password with quotes

### DIFF
--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	ovirtsdk "github.com/ovirt/go-ovirt"
 	"gopkg.in/yaml.v2"
@@ -90,6 +91,7 @@ func GetOvirtConfig() (*Config, error) {
 	}
 
 	err = yaml.Unmarshal(in, &c)
+	c.Password = strconv.Quote(c.Password)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ref: [bz-1933028](https://bugzilla.redhat.com/show_bug.cgi?id=1933028)

While fetching the OvirtConfig, wraps the config.Password into quotes. This could help to prevent the "storage operator" switching to a degraded state when the ovirt-api password starts with a reserved character.