### PR TITLE
Bug 2006201: Increase timeouts for CSI driver

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -116,9 +116,9 @@ spec:
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 10
+            initialDelaySeconds: 15
+            timeoutSeconds: 15
+            periodSeconds: 300
             failureThreshold: 5
           volumeMounts:
             - name: socket-dir

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -119,9 +119,9 @@ spec:
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 30
+            initialDelaySeconds: 15
+            timeoutSeconds: 15
+            periodSeconds: 300
             failureThreshold: 5
           resources:
             requests:


### PR DESCRIPTION
This change increases the timeout on the CSI driver health check to accommodate larger installations and make for a more reliable behavior with low volume network failures.