### PR TITLE
Set fsGroupPolicy in CSIDriver

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -8,3 +8,8 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  fsGroupPolicy: File
+  requiresRepublish: false
+  storageCapacity: false
+  volumeLifecycleModes:
+    - Persistent

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7
+	github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774
 	github.com/ovirt/go-ovirt-client v0.7.1
 	github.com/ovirt/go-ovirt-client-log-klog v1.0.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7 h1:GK+rgfQQpjZXCVE0MU/ch+HkImtIN1JXc9aRhH1aDj8=
-github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
+github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774 h1:GeCzQyJQ8biS12aYEbJrirh1DGmub2ZxcrNorMgR4XQ=
+github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db h1:ahvAlEurj4TF1SExDJHNeqknQC8lAwnZEPLyZJuRyd0=
 github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -2,14 +2,13 @@ package resourceapply
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
-	storageclientv1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -58,39 +57,18 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 	return actual, true, err
 }
 
-// ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else
-func ApplyCSIDriverV1Beta1(ctx context.Context, client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
-	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		requiredCopy := required.DeepCopy()
-		actual, err := client.CSIDrivers().Create(
-			ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*storagev1beta1.CSIDriver), metav1.CreateOptions{})
-		reportCreateEvent(recorder, required, err)
-		return actual, true, err
+// ApplyCSIDriver merges objectmeta, does not worry about anything else
+func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, requiredOriginal *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+
+	required := requiredOriginal.DeepCopy()
+	if required.Annotations == nil {
+		required.Annotations = map[string]string{}
 	}
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
 	if err != nil {
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
-	existingCopy := existing.DeepCopy()
-
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
-	}
-
-	if klog.V(4).Enabled() {
-		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
-	}
-
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
-	return actual, true, err
-}
-
-// ApplyCSIDriver merges objectmeta, does not worry about anything else
-func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
 	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
@@ -103,21 +81,46 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	metadataModified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
+	resourcemerge.EnsureObjectMeta(metadataModified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
+	requiredSpecHash := required.Annotations[specHashAnnotation]
+	existingSpecHash := existing.Annotations[specHashAnnotation]
+	sameSpec := requiredSpecHash == existingSpecHash
+	if sameSpec && !*metadataModified {
+		return existing, false, nil
 	}
 
 	if klog.V(4).Enabled() {
 		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	// TODO: Spec is read-only, so this will fail if user changes it. Should we simply ignore it?
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
+	if sameSpec {
+		// Update metadata by a simple Update call
+		actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, required, err)
+		return actual, true, err
+	}
+
+	existingCopy.Spec = required.Spec
+	existingCopy.ObjectMeta.ResourceVersion = ""
+	// Spec is read-only after creation. Delete and re-create the object
+	err = client.CSIDrivers().Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
+	reportDeleteEvent(recorder, existingCopy, err, "Deleting CSIDriver to re-create it with updated parameters")
+	if err != nil && !apierrors.IsNotFound(err) {
+		return existing, false, err
+	}
+	actual, err := client.CSIDrivers().Create(ctx, existingCopy, metav1.CreateOptions{})
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		// Delete() few lines above did not really delete the object,
+		// the API server is probably waiting for a finalizer removal or so.
+		// Report an error, but something else than "Already exists", because
+		// that would be very confusing - Apply failed because the object
+		// already exists???
+		err = fmt.Errorf("failed to re-create CSIDriver object %s, waiting for the original object to be deleted", existingCopy.Name)
+	}
+	reportCreateEvent(recorder, existingCopy, err)
 	return actual, true, err
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20220201080854-6d09ee4d3ce7
+# github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
And other CSIDriver fields. Since volumes of this CSI driver always support `fsGroup`, don't depend on Kubernetes heuristics (`ReadWriteOnceWithFSType`) and always apply it.

This updates library-go to https://github.com/openshift/library-go/pull/1324 to re-create driver's CSIDriver instance if the operator needs to change it.

It's somewhat related to https://bugzilla.redhat.com/show_bug.cgi?id=2058626, it makes sure the BZ never happens again.

cc @openshift/storage @janosdebugs 