### PR TITLE
OCPRHV-685 - added secret informer for daemonset

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -149,7 +149,11 @@ func (o *CSIOperator) RunOperator(ctx context.Context, controllerConfig *control
 		"node.yaml",
 		kubeClient,
 		kubeInformersForNamespaces.InformersFor(defaultNamespace),
-		[]factory.Informer{configMapInformer.Informer()},
+		[]factory.Informer{
+			configMapInformer.Informer(),
+			secretInformer.Informer(),
+		},
+		csidrivernodeservicecontroller.WithSecretHashAnnotationHook(defaultNamespace, secretName, secretInformer),
 		csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook(),
 		csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
 			defaultNamespace,

--- a/pkg/operator/storageclass_controller.go
+++ b/pkg/operator/storageclass_controller.go
@@ -58,12 +58,11 @@ func (c *OvirtStrogeClassController) sync(ctx context.Context, _ factory.SyncCon
 	existingStorageClass, err := c.kubeClient.StorageV1().StorageClasses().Get(ctx, storageClass.Name, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			klog.Errorf(
-				"failed to issue get request for storage class %s, error: %w", storageClass.Name, err)
+			klog.Errorf("failed to issue get request for storage class %s, error: %w", storageClass.Name, err)
 			return err
 		}
 	} else {
-		klog.Info("Storage Class %s already exists", existingStorageClass.Name)
+		klog.Infof("Storage Class %s already exists", existingStorageClass.Name)
 		storageClass = existingStorageClass
 	}
 
@@ -101,7 +100,7 @@ func (c *OvirtStrogeClassController) getStorageDomain(ctx context.Context) (stri
 				klog.Errorf("failed to fetch disk: %w", err)
 				return "", err
 			}
-			klog.Info("Extracting Storage Domain from disk: %s", d.ID())
+			klog.Infof("Extracting Storage Domain from disk: %s", d.ID())
 			storageDomains := d.StorageDomainIDs()
 			if len(storageDomains) == 0 {
 				return "", fmt.Errorf("no storage domains found on disk %s", d.ID())


### PR DESCRIPTION
This PR implements [OCPRHV-685](https://issues.redhat.com/browse/OCPRHV-685) for the daemonset of the csi-driver by adding the secret informer and annotation hook to the NodeService builder. 