### PR TITLE
Grant volumesnapshotcontents patch permissions to operator too

### DIFF
--- a/manifests/05_clusterrole.yaml
+++ b/manifests/05_clusterrole.yaml
@@ -198,6 +198,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:


### PR DESCRIPTION
Additional patch permission was granted in 0e068aae45dca983884e1c0236e66964897a4b43 to ovirt-external-snapshotter-role. Operator fails to create/update role if it doesn't have the right itself (`is attempting to grant RBAC permissions no t currently held` warning event)